### PR TITLE
cleaner API for object properties and nullable values

### DIFF
--- a/jwriter/no_op_writer.go
+++ b/jwriter/no_op_writer.go
@@ -1,0 +1,15 @@
+package jwriter
+
+var noOpWriter = makeNoOpWriter() //nolint:gochecknoglobals
+
+func makeNoOpWriter() Writer {
+	w := Writer{}
+	w.AddError(noOpWriterError{})
+	return w
+}
+
+type noOpWriterError struct{}
+
+func (noOpWriterError) Error() string {
+	return "this is a stub Writer that produces no output"
+}

--- a/jwriter/package_example_test.go
+++ b/jwriter/package_example_test.go
@@ -6,7 +6,7 @@ func Example() {
 	w := NewWriter()
 
 	obj := w.Object()
-	obj.String("propertyName", "propertyValue")
+	obj.Name("propertyName").String("propertyValue")
 	obj.End()
 
 	if err := w.Error(); err != nil {

--- a/jwriter/package_info.go
+++ b/jwriter/package_info.go
@@ -13,7 +13,7 @@
 //
 //     func (s myStruct) WriteToJSONWriter(w *jwriter.Writer) {
 //         obj := w.Object() // writing a JSON object structure like {"value":2}
-//         obj.Int("value", s.value)
+//         obj.Property("value").Int(s.value)
 //         obj.End()
 //     }
 //

--- a/jwriter/testdata_test.go
+++ b/jwriter/testdata_test.go
@@ -9,9 +9,9 @@ type ExampleStructWrapper commontest.ExampleStruct
 
 func (s ExampleStructWrapper) WriteToJSONWriter(w *Writer) {
 	obj := w.Object()
-	obj.String(commontest.ExampleStructStringFieldName, s.StringField)
-	obj.Int(commontest.ExampleStructIntFieldName, s.IntField)
-	obj.Property(commontest.ExampleStructOptBoolAsInterfaceFieldName)
+	obj.Name(commontest.ExampleStructStringFieldName).String(s.StringField)
+	obj.Name(commontest.ExampleStructIntFieldName).Int(s.IntField)
+	obj.Name(commontest.ExampleStructOptBoolAsInterfaceFieldName)
 	if s.OptBoolAsInterfaceField == nil {
 		w.Null()
 	} else {

--- a/jwriter/writer.go
+++ b/jwriter/writer.go
@@ -73,10 +73,30 @@ func (w *Writer) Bool(value bool) {
 	}
 }
 
+// BoolOrNull is a shortcut for calling Bool(value) if isDefined is true, or else
+// Null().
+func (w *Writer) BoolOrNull(isDefined bool, value bool) {
+	if isDefined {
+		w.Bool(value)
+	} else {
+		w.Null()
+	}
+}
+
 // Int writes a JSON numeric value to the output.
 func (w *Writer) Int(value int) {
 	if w.beforeValue() {
 		w.AddError(w.tw.Int(value))
+	}
+}
+
+// IntOrNull is a shortcut for calling Int(value) if isDefined is true, or else
+// Null().
+func (w *Writer) IntOrNull(isDefined bool, value int) {
+	if isDefined {
+		w.Int(value)
+	} else {
+		w.Null()
 	}
 }
 
@@ -87,6 +107,16 @@ func (w *Writer) Float64(value float64) {
 	}
 }
 
+// Float64OrNull is a shortcut for calling Float64(value) if isDefined is true, or else
+// Null().
+func (w *Writer) Float64OrNull(isDefined bool, value float64) {
+	if isDefined {
+		w.Float64(value)
+	} else {
+		w.Null()
+	}
+}
+
 // String writes a JSON string value to the output, adding quotes and performing any necessary escaping.
 func (w *Writer) String(value string) {
 	if w.beforeValue() {
@@ -94,10 +124,22 @@ func (w *Writer) String(value string) {
 	}
 }
 
+// StringOrNull is a shortcut for calling String(value) if isDefined is true, or else
+// Null().
+func (w *Writer) StringOrNull(isDefined bool, value string) {
+	if isDefined {
+		w.String(value)
+	} else {
+		w.Null()
+	}
+}
+
 // Raw writes a pre-encoded JSON value to the output as-is. Its format is assumed to be correct; this
 // operation will not fail unless it is not permitted to write a value at this point.
 func (w *Writer) Raw(value json.RawMessage) {
-	if w.beforeValue() {
+	if value == nil {
+		w.Null()
+	} else if w.beforeValue() {
 		w.AddError(w.tw.Raw(value))
 	}
 }

--- a/jwriter/writer_array_examples_test.go
+++ b/jwriter/writer_array_examples_test.go
@@ -78,10 +78,10 @@ func ExampleArrayState_Object() {
 	w := NewWriter()
 	arr := w.Array()
 	obj1 := arr.Object()
-	obj1.Int("value", 1)
+	obj1.Name("value").Int(1)
 	obj1.End()
 	obj2 := arr.Object()
-	obj2.Int("value", 2)
+	obj2.Name("value").Int(2)
 	obj2.End()
 	arr.End()
 

--- a/jwriter/writer_array_test.go
+++ b/jwriter/writer_array_test.go
@@ -22,7 +22,7 @@ func TestArrayState(t *testing.T) {
 	aa.End()
 
 	ao := a.Object()
-	ao.Int("seven", 7)
+	ao.Name("seven").Int(7)
 	ao.End()
 
 	a.End()

--- a/jwriter/writer_benchmark_test.go
+++ b/jwriter/writer_benchmark_test.go
@@ -105,6 +105,22 @@ func benchmarkExpectWriterOutput(b *testing.B, w *Writer, expectedJSON []byte) {
 	}
 }
 
+func BenchmarkWriteObjectToNoOpWriterNoAllocs(b *testing.B) {
+	// The purpose of this benchmark is to ensure that nothing is escaping to the heap simply
+	// as result of calling the Name or Maybe methods (as it might if we hadn't been
+	// careful about our use of pointers). We're preinitializing the Writer to already have an
+	// error, so it won't produce any output.
+	w := NewWriter()
+	obj := w.Object()
+	w.AddError(noOpWriterError{})
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		obj.Name("prop1").Int(1)
+		obj.Maybe("prop2", true).Int(2)
+		obj.Maybe("prop3", false).Int(3)
+	}
+}
+
 func BenchmarkStreamingWriterArrayOfStrings(b *testing.B) {
 	vals := commontest.MakeStrings()
 	expected := commontest.MakeStringsJSON(vals)

--- a/jwriter/writer_examples_test.go
+++ b/jwriter/writer_examples_test.go
@@ -10,7 +10,7 @@ import (
 func ExampleNewWriter() {
 	w := NewWriter()
 	obj := w.Object()
-	obj.String("property", "value")
+	obj.Name("property").String("value")
 	obj.End()
 	fmt.Println(string(w.Bytes()))
 	// Output: {"property":"value"}
@@ -19,7 +19,7 @@ func ExampleNewWriter() {
 func ExampleNewStreamingWriter() {
 	w := NewStreamingWriter(os.Stdout, 10)
 	obj := w.Object()
-	obj.String("property", "value")
+	obj.Name("property").String("value")
 	obj.End()
 	w.Flush()
 	// Output: {"property":"value"}
@@ -28,9 +28,9 @@ func ExampleNewStreamingWriter() {
 func ExampleWriter_AddError() {
 	w := NewWriter()
 	obj := w.Object()
-	obj.Bool("prop1", true)
+	obj.Name("prop1").Bool(true)
 	w.AddError(errors.New("sorry, we can't serialize this after all"))
-	obj.Bool("prop2", true) // no output is generated here because the Writer has already failed
+	obj.Name("prop2").Bool(true) // no output is generated here because the Writer has already failed
 	fmt.Println("error is:", w.Error())
 	fmt.Println("buffer is:", string(w.Bytes()))
 	// Output: error is: sorry, we can't serialize this after all
@@ -51,11 +51,25 @@ func ExampleWriter_Bool() {
 	// Output: true
 }
 
+func ExampleWriter_BoolOrNull() {
+	w := NewWriter()
+	w.BoolOrNull(false, true)
+	fmt.Println(string(w.Bytes()))
+	// Output: null
+}
+
 func ExampleWriter_Int() {
 	w := NewWriter()
 	w.Int(123)
 	fmt.Println(string(w.Bytes()))
 	// Output: 123
+}
+
+func ExampleWriter_IntOrNull() {
+	w := NewWriter()
+	w.IntOrNull(false, 1)
+	fmt.Println(string(w.Bytes()))
+	// Output: null
 }
 
 func ExampleWriter_Float64() {
@@ -65,11 +79,25 @@ func ExampleWriter_Float64() {
 	// Output: 1234.5
 }
 
+func ExampleWriter_Float64OrNull() {
+	w := NewWriter()
+	w.Float64OrNull(false, 1)
+	fmt.Println(string(w.Bytes()))
+	// Output: null
+}
+
 func ExampleWriter_String() {
 	w := NewWriter()
 	w.String(`string says "hello"`)
 	fmt.Println(string(w.Bytes()))
 	// Output: "string says \"hello\""
+}
+
+func ExampleWriter_StringOrNull() {
+	w := NewWriter()
+	w.StringOrNull(false, "no")
+	fmt.Println(string(w.Bytes()))
+	// Output: null
 }
 
 func ExampleWriter_Array() {
@@ -85,8 +113,8 @@ func ExampleWriter_Array() {
 func ExampleWriter_Object() {
 	w := NewWriter()
 	obj := w.Object()
-	obj.Bool("boolProperty", true)
-	obj.Int("intProperty", 3)
+	obj.Name("boolProperty").Bool(true)
+	obj.Name("intProperty").Int(3)
 	obj.End()
 	fmt.Println(string(w.Bytes()))
 	// Output: {"boolProperty":true,"intProperty":3}

--- a/jwriter/writer_init_easyjson_test.go
+++ b/jwriter/writer_init_easyjson_test.go
@@ -25,9 +25,7 @@ func TestNewWriterFromEasyJSONWriter(t *testing.T) {
 	writer := NewWriterFromEasyJSONWriter(&ejw)
 	obj := writer.Object()
 	require.NoError(t, writer.Error())
-	obj.Property("property")
-	require.NoError(t, writer.Error())
-	writer.Int(2)
+	obj.Name("property").Int(2)
 	require.NoError(t, writer.Error())
 	obj.End()
 

--- a/jwriter/writer_object.go
+++ b/jwriter/writer_object.go
@@ -29,17 +29,17 @@ func (obj *ObjectState) Name(name string) *Writer {
 }
 
 // Maybe writes an object property name conditionally depending on a boolean parameter.
-// If present is true, this behaves the same as Property(name). However, if present is false,
+// If shouldWrite is true, this behaves the same as Property(name). However, if shouldWrite is false,
 // it does not write a property name and instead of returning the underlying Writer, it returns
 // a stub Writer that does not produce any output. This allows you to chain method calls without
 // having to use an if statement.
 //
 //     obj.Maybe(shouldWeIncludeTheProperty, "myBooleanProperty").Bool(true)
-func (obj *ObjectState) Maybe(name string, present bool) *Writer {
+func (obj *ObjectState) Maybe(name string, shouldWrite bool) *Writer {
 	if obj.w == nil {
 		return &noOpWriter
 	}
-	if present {
+	if shouldWrite {
 		return obj.Name(name)
 	}
 	return &noOpWriter

--- a/jwriter/writer_object.go
+++ b/jwriter/writer_object.go
@@ -1,7 +1,5 @@
 package jwriter
 
-import "encoding/json"
-
 // ObjectWriter is a decorator that writes values to an underlying Writer within the context of a
 // JSON object, adding property names and commas between values as appropriate.
 type ObjectState struct {
@@ -10,11 +8,14 @@ type ObjectState struct {
 	previousState writerState
 }
 
-// Property writes an object property name and a colon. You can then use Writer methods to write
-// the property value. The return value is the same as the underlying Writer.
-func (obj *ObjectState) Property(name string) *Writer {
+// Name writes an object property name and a colon. You can then use Writer methods to write
+// the property value. The return value is the same as the underlying Writer, so you can chain
+// method calls:
+//
+//     obj.Name("myBooleanProperty").Bool(true)
+func (obj *ObjectState) Name(name string) *Writer {
 	if obj.w == nil || obj.w.err != nil {
-		return obj.w
+		return &noOpWriter
 	}
 	if obj.hasItems {
 		if err := obj.w.tw.Delimiter(','); err != nil {
@@ -27,98 +28,21 @@ func (obj *ObjectState) Property(name string) *Writer {
 	return obj.w
 }
 
-// Null is a shortcut for calling Property(name) followed by writer.Null().
-func (obj *ObjectState) Null(name string) {
-	if obj.w != nil {
-		obj.Property(name)
-		obj.w.Null()
+// Maybe writes an object property name conditionally depending on a boolean parameter.
+// If present is true, this behaves the same as Property(name). However, if present is false,
+// it does not write a property name and instead of returning the underlying Writer, it returns
+// a stub Writer that does not produce any output. This allows you to chain method calls without
+// having to use an if statement.
+//
+//     obj.Maybe(shouldWeIncludeTheProperty, "myBooleanProperty").Bool(true)
+func (obj *ObjectState) Maybe(name string, present bool) *Writer {
+	if obj.w == nil {
+		return &noOpWriter
 	}
-}
-
-// Bool is a shortcut for calling Property(name) followed by writer.Bool(value).
-func (obj *ObjectState) Bool(name string, value bool) {
-	if obj.w != nil {
-		obj.Property(name)
-		obj.w.Bool(value)
+	if present {
+		return obj.Name(name)
 	}
-}
-
-// Int is a shortcut for calling Property(name) followed by writer.Int(value).
-func (obj *ObjectState) Int(name string, value int) {
-	if obj.w != nil {
-		obj.Property(name)
-		obj.w.Int(value)
-	}
-}
-
-// Float64 is a shortcut for calling Property(name) followed by writer.Float64(value).
-func (obj *ObjectState) Float64(name string, value float64) {
-	if obj.w != nil {
-		obj.Property(name)
-		obj.w.Float64(value)
-	}
-}
-
-// String is a shortcut for calling Property(name) followed by writer.String(value).
-func (obj *ObjectState) String(name string, value string) {
-	if obj.w != nil {
-		obj.Property(name)
-		obj.w.String(value)
-	}
-}
-
-// OptBool is a shortcut for calling Bool(name, value) if isDefined is true.
-func (obj *ObjectState) OptBool(name string, isDefined bool, value bool) {
-	if isDefined {
-		obj.Bool(name, value)
-	}
-}
-
-// OptInt is a shortcut for calling Int(name, value) if isDefined is true.
-func (obj *ObjectState) OptInt(name string, isDefined bool, value int) {
-	if isDefined {
-		obj.Int(name, value)
-	}
-}
-
-// OptFloat64 is a shortcut for calling Float64(name, value) if isDefined is true.
-func (obj *ObjectState) OptFloat64(name string, isDefined bool, value float64) {
-	if isDefined {
-		obj.Float64(name, value)
-	}
-}
-
-// OptString is a shortcut for calling String(name, value) if isDefined is true.
-func (obj *ObjectState) OptString(name string, isDefined bool, value string) {
-	if isDefined {
-		obj.String(name, value)
-	}
-}
-
-// Array is a shortcut for calling Property(name) followed by writer.Array(), to create a nested array.
-func (obj *ObjectState) Array(name string) ArrayState {
-	if obj.w != nil {
-		obj.Property(name)
-		return obj.w.Array()
-	}
-	return ArrayState{}
-}
-
-// Object is a shortcut for calling Property(name) followed by writer.Object(), to create a nested object.
-func (obj *ObjectState) Object(name string) ObjectState {
-	if obj.w != nil {
-		obj.Property(name)
-		return obj.w.Object()
-	}
-	return ObjectState{}
-}
-
-// Raw is a shortcut for calling Property(name) followed by writer.Raw().
-func (obj *ObjectState) Raw(name string, value json.RawMessage) {
-	if obj.w != nil {
-		obj.Property(name)
-		obj.w.Raw(value)
-	}
+	return &noOpWriter
 }
 
 // End writes the closing delimiter of the object.

--- a/jwriter/writer_object_examples_test.go
+++ b/jwriter/writer_object_examples_test.go
@@ -1,153 +1,33 @@
 package jwriter
 
 import (
-	"encoding/json"
 	"fmt"
 )
 
-func ExampleObjectState_Property() {
+func ExampleObjectState_Name() {
 	myCustomMarshaler := func(w *Writer) {
 		subObject := w.Object()
-		subObject.Bool("yes", true)
+		subObject.Name("yes").Bool(true)
 		subObject.End()
 	}
 
 	w := NewWriter()
 
 	obj := w.Object()
-	myCustomMarshaler(obj.Property("subObject"))
+	myCustomMarshaler(obj.Name("subObject"))
 	obj.End()
 
 	fmt.Println(string(w.Bytes()))
 	// Output: {"subObject":{"yes":true}}
 }
 
-func ExampleObjectState_Null() {
+func ExampleObjectState_Maybe() {
 	w := NewWriter()
 	obj := w.Object()
-	obj.Null("property")
+	obj.Maybe("notPresent", false).Int(1)
+	obj.Maybe("present", true).Int(2)
 	obj.End()
 
 	fmt.Println(string(w.Bytes()))
-	// Output: {"property":null}
-}
-
-func ExampleObjectState_Bool() {
-	w := NewWriter()
-	obj := w.Object()
-	obj.Bool("property", true)
-	obj.End()
-
-	fmt.Println(string(w.Bytes()))
-	// Output: {"property":true}
-}
-
-func ExampleObjectState_Int() {
-	w := NewWriter()
-	obj := w.Object()
-	obj.Int("property", 123)
-	obj.End()
-
-	fmt.Println(string(w.Bytes()))
-	// Output: {"property":123}
-}
-
-func ExampleObjectState_Float64() {
-	w := NewWriter()
-	obj := w.Object()
-	obj.Float64("property", 1234.5)
-	obj.End()
-
-	fmt.Println(string(w.Bytes()))
-	// Output: {"property":1234.5}
-}
-
-func ExampleObjectState_String() {
-	w := NewWriter()
-	obj := w.Object()
-	obj.String("property", `string says "hello"`)
-	obj.End()
-
-	fmt.Println(string(w.Bytes()))
-	// Output: {"property":"string says \"hello\""}
-}
-
-func ExampleObjectState_Array() {
-	w := NewWriter()
-	obj := w.Object()
-	arr := obj.Array("property")
-	arr.Int(1)
-	arr.Int(2)
-	arr.End()
-	obj.End()
-
-	fmt.Println(string(w.Bytes()))
-	// Output: {"property":[1,2]}
-}
-
-func ExampleObjectState_Object() {
-	w := NewWriter()
-	obj := w.Object()
-	subObj := obj.Object("property")
-	subObj.Int("value", 1)
-	subObj.End()
-	obj.End()
-
-	fmt.Println(string(w.Bytes()))
-	// Output: {"property":{"value":1}}
-}
-
-func ExampleObjectState_OptBool() {
-	w := NewWriter()
-	obj := w.Object()
-	obj.OptBool("notPresent", false, true)
-	obj.OptBool("present", true, true)
-	obj.End()
-
-	fmt.Println(string(w.Bytes()))
-	// Output: {"present":true}
-}
-
-func ExampleObjectState_OptInt() {
-	w := NewWriter()
-	obj := w.Object()
-	obj.OptInt("notPresent", false, 123)
-	obj.OptInt("present", true, 456)
-	obj.End()
-
-	fmt.Println(string(w.Bytes()))
-	// Output: {"present":456}
-}
-
-func ExampleObjectState_OptFloat64() {
-	w := NewWriter()
-	obj := w.Object()
-	obj.OptFloat64("property", false, 1234.5)
-	obj.OptFloat64("present", true, 6)
-	obj.End()
-
-	fmt.Println(string(w.Bytes()))
-	// Output: {"present":6}
-}
-
-func ExampleObjectState_OptString() {
-	w := NewWriter()
-	obj := w.Object()
-	obj.OptString("notPresent", false, "a")
-	obj.OptString("present", true, "b")
-	obj.End()
-
-	fmt.Println(string(w.Bytes()))
-	// Output: {"present":"b"}
-}
-
-func ExampleObjectState_Raw() {
-	data := json.RawMessage(`{"value":1}`)
-	w := NewWriter()
-	obj := w.Object()
-	obj.Raw("data", data)
-	obj.End()
-
-	fmt.Println(string(w.Bytes()))
-	// Output: {"data":{"value":1}}
+	// Output: {"present":2}
 }

--- a/jwriter/writer_object_test.go
+++ b/jwriter/writer_object_test.go
@@ -11,37 +11,21 @@ func TestObjectState(t *testing.T) {
 	w := NewWriter()
 	o := w.Object()
 
-	o.Property("prop0")
-	w.String("value0")
+	o.Name("prop1").Bool(true)
+	o.Maybe("prop2", true).Bool(true)
+	o.Maybe("shouldNotWriteThis", false).Bool(true)
 
-	o.Null("prop1")
-	o.Bool("prop2", true)
-	o.Int("prop3", 3)
-	o.Float64("prop4", 4.5)
-	o.String("prop5", "five")
-
-	o.OptBool("no1", false, false)
-	o.OptInt("no2", false, 9)
-	o.OptFloat64("no3", false, 9.5)
-	o.OptString("no4", false, "x")
-
-	o.OptBool("prop6", true, false)
-	o.OptInt("prop7", true, 9)
-	o.OptFloat64("prop8", true, 9.5)
-	o.OptString("prop9", true, "x")
-
-	oa := o.Array("propa")
-	oa.Int(10)
+	oa := o.Name("nestedArray").Array()
+	oa.Int(1)
 	oa.End()
 
-	oo := o.Object("propo")
-	oo.Int("eleven", 11)
+	oo := o.Name("nestedObject").Object()
+	oo.Name("eleven").Int(11)
 	oo.End()
 
 	o.End()
 
 	require.NoError(t, w.Error())
-	expected := `{"prop0":"value0","prop1":null,"prop2":true,"prop3":3,"prop4":4.5,"prop5":"five",` +
-		`"prop6":false,"prop7":9,"prop8":9.5,"prop9":"x","propa":[10],"propo":{"eleven":11}}`
+	expected := `{"prop1":true,"prop2":true,"nestedArray":[1],"nestedObject":{"eleven":11}}`
 	assert.JSONEq(t, expected, string(w.Bytes()))
 }

--- a/jwriter/writer_test.go
+++ b/jwriter/writer_test.go
@@ -104,7 +104,7 @@ func (f writerValueTestFactory) Value(value commontest.AnyValue, variant commont
 		case commontest.ObjectValue:
 			obj := w.Object()
 			for _, p := range value.Object {
-				obj.Property(p.Name)
+				obj.Name(p.Name)
 				if err := p.Action(ctx); err != nil {
 					return err
 				}


### PR DESCRIPTION
This is a slight rethink of the `jwriter` AP, based on some changes I made while porting it to .NET.

Previously, writing a JSON object looked like this:

```go
    obj := w.Object()
    obj.String("myStringProperty", "stringValue")
    obj.Int("myNumericProperty", 2)
```

So `ObjectState` (the type of `obj` here) had to have methods corresponding to each of the JSON types, the same as the corresponding `Writer` methods except with an extra property name parameter. There were also `OptString`, `OptInt`, etc. which were for optional properties. And there was a `Property` method, for cases where you didn't know the value right away but just wanted to write the name and then call some other marshaling method to write the value.

I've simplified this by replacing `Null(name)`, `Bool(name, value)`, `Int(name, value)`, `Float64(name, value)`, `String(name, value)`, `Array(name)`, and `Object(name)` with `func (obj *ObjectState) Name(name string) *Writer`. Since it returns the original `*Writer`, you can just call the already-existing `Writer` methods to write the value, with method chaining:

```go
    obj := w.Object()
    obj.Name("myStringProperty").String("stringValue")
    obj.Name("myNumericProperty").Int(2)
```

I also replaced all the `Opt` methods with `func (obj *ObjectState) Maybe(name string, shouldWrite bool) *Writer`, which works just like `Name` except that if `shouldWrite` is false, it doesn't write the property and the `*Writer` that it returns is a stub that won't produce any output.

```go
    obj.Maybe("wontActuallyWriteThisProperty", false).String("stringValue")
```

Also, in `Writer`, I added `BoolOrNull`, `StringOrNull`, etc. which are simply shortcuts for having to do an if/else when you have a nullable value. This is symmetrical with the way `BoolOrNull` et al. work in `jreader.Reader`.