### PR TITLE
fix float parsing when there's an exponent but no decimal

### DIFF
--- a/internal/commontest/test_values.go
+++ b/internal/commontest/test_values.go
@@ -47,10 +47,14 @@ func makeNumberTestValues(encodingBehavior encodingBehavior) []testValue {
 		{"int large", 1603312301195, "1603312301195", ""}, // enough magnitude for a millisecond timestamp
 		{"float", 3.5, "3.5", ""},
 		{"float negative", -3.5, "-3.5", ""},
-		{"float with exp", 3500, "3.5e3", "3500"},
-		{"float with Exp", 3500, "3.5E3", "3500"},
-		{"float with exp+", 3500, "3.5e+3", "3500"},
-		{"float with exp-", 0.0035, "3.5e-3", "0.0035"},
+		{"float with exp and decimal", 3500, "3.5e3", "3500"},
+		{"float with Exp and decimal", 3500, "3.5E3", "3500"},
+		{"float with exp+ and decimal", 3500, "3.5e+3", "3500"},
+		{"float with exp- and decimal", 0.0035, "3.5e-3", "0.0035"},
+		{"float with exp but no decimal", 5000, "5e3", "5000"},
+		{"float with Exp but no decimal", 5000, "5E3", "5000"},
+		{"float with exp+ but no decimal", 5000, "5e+3", "5000"},
+		{"float with exp- but no decimal", 0.005, "5e-3", "0.005"},
 	} {
 		enc := v.encoding
 		if !encodingBehavior.forParsing && v.simplestEncoding != "" {


### PR DESCRIPTION
Parsing of numeric values in the default implementation was broken for all numbers that have an exponent but do _not_ have a decimal. For such numbers, the parser was returning an integer value based on misusing the ASCII values of the non-digit characters as if they were digits, e.g. `1e-5` was interpreted as `88035`.

This bug did not occur in the EasyJSON implementation of the parser. It would have been caught by the test suite for the default implementation, except that the test data unfortunately only covered the "no decimal and no exponent", "decimal and no exponent", and "decimal and exponent" cases, not "no decimal and exponent". Adding this case to the test data correctly flagged the bug, and the tests then pass with the fix.