### PR TITLE
add CI job for Go 1.17; update linter & test coverage script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,10 @@ workflows:
   workflow:
     jobs:
       - go-test:
+          name: Go 1.17
+          docker-image: cimg/go:1.17
+          run-lint: true
+      - go-test:
           name: Go 1.16
           docker-image: cimg/go:1.16
       - go-test:
@@ -21,9 +25,7 @@ jobs:
         type: string
       run-lint:
         type: boolean
-        default: true
-        # We are currently linting in all Go versions, but this parameter lets us turn it off for some, in
-        # case we need to support more versions than a single version of golangci-lint is compatible with
+        default: false
       with-coverage:
         type: boolean
         default: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,53 @@
+run:
+  deadline: 120s
+  tests: false
+  skip-dirs: commontest
+
+linters:
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dupl
+    - errcheck
+    - goconst
+    - gochecknoglobals
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - godox
+    - gofmt
+    - goimports
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - megacheck
+    - misspell
+    - nakedret
+    - nolintlint
+    - prealloc
+    - revive
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+  fast: false
+
+linters-settings:
+  gofmt:
+    simplify: false
+  goimports:
+    local-prefixes: gopkg.in/launchdarkly,github.com/launchdarkly
+  
+issues:
+  exclude-use-default: false
+  max-same-issues: 1000
+  max-per-linter: 1000

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-GOLANGCI_LINT_VERSION=v1.27.0
+GOLANGCI_LINT_VERSION=v1.42.1
 
 LINTER=./bin/golangci-lint
 LINTER_VERSION_FILE=./bin/.golangci-lint-version-$(GOLANGCI_LINT_VERSION)
@@ -38,8 +38,7 @@ test-easyjson: build-easyjson
 	go test $(EASYJSON_TAG) -count 1 ./...
 
 test-coverage: $(COVERAGE_PROFILE_RAW)
-	if [ -z "$(which go-coverage-enforcer)" ]; then go install github.com/launchdarkly-labs/go-coverage-enforcer; fi
-	go-coverage-enforcer $(COVERAGE_ENFORCER_FLAGS) -outprofile $(COVERAGE_PROFILE_FILTERED) $(COVERAGE_PROFILE_RAW)
+	go run github.com/launchdarkly-labs/go-coverage-enforcer@latest $(COVERAGE_ENFORCER_FLAGS) -outprofile $(COVERAGE_PROFILE_FILTERED) $(COVERAGE_PROFILE_RAW)
 	go tool cover -html $(COVERAGE_PROFILE_FILTERED) -o $(COVERAGE_PROFILE_FILTERED_HTML)
 	go tool cover -html $(COVERAGE_PROFILE_RAW) -o $(COVERAGE_PROFILE_RAW_HTML)
 

--- a/jreader/interfaces.go
+++ b/jreader/interfaces.go
@@ -33,7 +33,7 @@ const (
 	// BoolValue means the value is a boolean.
 	BoolValue ValueKind = iota
 
-	// NumberToken means the value is a number.
+	// NumberValue means the value is a number.
 	NumberValue ValueKind = iota
 
 	// StringValue means the value is a string.

--- a/jreader/reader.go
+++ b/jreader/reader.go
@@ -380,7 +380,7 @@ func (r *Reader) SkipValue() error {
 
 func typeErrorForNullableValue(err error) error {
 	if err != nil {
-		switch e := err.(type) {
+		switch e := err.(type) { //nolint:gocritic
 		case TypeError:
 			e.Nullable = true
 			return e

--- a/jreader/reader_init_easyjson.go
+++ b/jreader/reader_init_easyjson.go
@@ -1,3 +1,4 @@
+//go:build launchdarkly_easyjson
 // +build launchdarkly_easyjson
 
 package jreader

--- a/jreader/reader_init_easyjson_test.go
+++ b/jreader/reader_init_easyjson_test.go
@@ -1,3 +1,4 @@
+//go:build launchdarkly_easyjson
 // +build launchdarkly_easyjson
 
 package jreader

--- a/jreader/reader_object.go
+++ b/jreader/reader_object.go
@@ -165,9 +165,9 @@ func (obj *ObjectState) Name() []byte {
 // to the array (obj.requiredProps = obj.requiredPropsFound[0:len(obj.requiredProps)]); the Go
 // compiler can't prove that that's safe, so it will make everything escape to the heap. Instead
 // we have to conditionally reference one or the other here.
-func (o *ObjectState) requiredPropsFoundSlice() []bool {
-	if o.requiredPropsFound != nil {
-		return o.requiredPropsFound
+func (obj *ObjectState) requiredPropsFoundSlice() []bool {
+	if obj.requiredPropsFound != nil {
+		return obj.requiredPropsFound
 	}
-	return o.requiredPropsPrealloc[0:len(o.requiredProps)]
+	return obj.requiredPropsPrealloc[0:len(obj.requiredProps)]
 }

--- a/jreader/token_reader_default.go
+++ b/jreader/token_reader_default.go
@@ -1,3 +1,4 @@
+//go:build !launchdarkly_easyjson
 // +build !launchdarkly_easyjson
 
 package jreader
@@ -378,7 +379,7 @@ func (r *tokenReader) consumeASCIILowercaseAlphabeticChars() int {
 	return n
 }
 
-func (r *tokenReader) readNumber(first byte) (float64, bool) {
+func (r *tokenReader) readNumber(first byte) (float64, bool) { //nolint:unparam
 	startPos := r.lastPos
 	isFloat := false
 	var ch byte
@@ -402,7 +403,7 @@ func (r *tokenReader) readNumber(first byte) (float64, bool) {
 		if !ok {
 			return 0, false
 		}
-		if ch == '+' || ch == '-' {
+		if ch == '+' || ch == '-' { //nolint:gocritic
 		} else if ch >= '0' && ch <= '9' {
 			r.unreadByte()
 		} else {
@@ -423,7 +424,7 @@ func (r *tokenReader) readNumber(first byte) (float64, bool) {
 			return 0, false
 		}
 		isFloat = true
-	} else {
+	} else { //nolint:gocritic
 		if ok {
 			r.unreadByte()
 		}
@@ -435,7 +436,7 @@ func (r *tokenReader) readNumber(first byte) (float64, bool) {
 		// at the existing bytes, but in our default implementation we can't use unsafe.
 		n, err := strconv.ParseFloat(string(chars), 64)
 		return n, err == nil
-	} else {
+	} else { //nolint:revive
 		n, ok := parseIntFromBytes(chars)
 		return float64(n), ok
 	}
@@ -504,7 +505,7 @@ func (r *tokenReader) readString() ([]byte, error) {
 			return nil, nil
 		}
 		return chars, nil
-	} else {
+	} else { //nolint:revive
 		pos := r.pos - 1
 		if pos <= startPos {
 			return nil, nil
@@ -526,7 +527,7 @@ func readHexChar(reader *bytes.Reader) (rune, bool) {
 	return rune(n), true
 }
 
-func (r *tokenReader) syntaxErrorOnLastToken(msg string) error {
+func (r *tokenReader) syntaxErrorOnLastToken(msg string) error { //nolint:unparam
 	return SyntaxError{Message: msg, Offset: r.LastPos()}
 }
 

--- a/jreader/token_reader_easyjson.go
+++ b/jreader/token_reader_easyjson.go
@@ -1,3 +1,4 @@
+//go:build launchdarkly_easyjson
 // +build launchdarkly_easyjson
 
 package jreader

--- a/jwriter/test_behavior_default.go
+++ b/jwriter/test_behavior_default.go
@@ -1,9 +1,10 @@
+//go:build !launchdarkly_easyjson
 // +build !launchdarkly_easyjson
 
 package jwriter
 
 // This function tells the writer tests that we shouldn't expect to see hex escape sequences in the output.
 // Our default implementation doesn't use them, whereas easyjson does; either way is valid in JSON.
-func tokenWriterWillEncodeAsHex(ch rune) bool {
+func tokenWriterWillEncodeAsHex(ch rune) bool { //nolint:deadcode,unused // linter is confused
 	return false
 }

--- a/jwriter/test_behavior_easyjson.go
+++ b/jwriter/test_behavior_easyjson.go
@@ -1,9 +1,10 @@
+//go:build launchdarkly_easyjson
 // +build launchdarkly_easyjson
 
 package jwriter
 
 // This function tells the writer tests that we should expect to see hex escape sequences in the output
 // for certain characters, because that's the behavior of easyjson.
-func tokenWriterWillEncodeAsHex(ch rune) bool {
+func tokenWriterWillEncodeAsHex(ch rune) bool { //nolint:deadcode,unused // linter is confused
 	return ch != '\t' && ch != '\n' && ch != '\r'
 }

--- a/jwriter/token_writer_default.go
+++ b/jwriter/token_writer_default.go
@@ -1,3 +1,4 @@
+//go:build !launchdarkly_easyjson
 // +build !launchdarkly_easyjson
 
 package jwriter

--- a/jwriter/token_writer_easyjson.go
+++ b/jwriter/token_writer_easyjson.go
@@ -1,3 +1,4 @@
+//go:build launchdarkly_easyjson
 // +build launchdarkly_easyjson
 
 package jwriter

--- a/jwriter/writer_init_easyjson.go
+++ b/jwriter/writer_init_easyjson.go
@@ -1,3 +1,4 @@
+//go:build launchdarkly_easyjson
 // +build launchdarkly_easyjson
 
 package jwriter

--- a/jwriter/writer_init_easyjson_test.go
+++ b/jwriter/writer_init_easyjson_test.go
@@ -1,3 +1,4 @@
+//go:build launchdarkly_easyjson
 // +build launchdarkly_easyjson
 
 package jwriter

--- a/jwriter/writer_object.go
+++ b/jwriter/writer_object.go
@@ -1,6 +1,6 @@
 package jwriter
 
-// ObjectWriter is a decorator that writes values to an underlying Writer within the context of a
+// ObjectState is a decorator that writes values to an underlying Writer within the context of a
 // JSON object, adding property names and commas between values as appropriate.
 type ObjectState struct {
 	w             *Writer

--- a/jwriter/writer_streaming_default_test.go
+++ b/jwriter/writer_streaming_default_test.go
@@ -1,3 +1,4 @@
+//go:build !launchdarkly_easyjson
 // +build !launchdarkly_easyjson
 
 package jwriter

--- a/jwriter/writer_streaming_easyjson_test.go
+++ b/jwriter/writer_streaming_easyjson_test.go
@@ -1,3 +1,4 @@
+//go:build launchdarkly_easyjson
 // +build launchdarkly_easyjson
 
 package jwriter


### PR DESCRIPTION
The only Go code changes in this PR that are not comments are about parameter naming (due to the linter being stricter about consistent naming), which don't affect functionality. I deliberately did _not_ implement the linter's suggestions like "use an early return instead of an else" because I wanted this PR to be a simple build tooling update without any potential for unintended logic changes.

Also, even though the Makefile contains a `test-coverage` target, we have not actually been running the coverage enforcer tool in this project's CI so far, and I've kept it that way because making it reach the 100% coverage goal would require a fair amount of test code updates which are outside the scope of this PR.