### PR TITLE
Go versions update + stop using gopkg.in

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,10 @@ workflows:
       - go-test:
           name: Go 1.18
           docker-image: cimg/go:1.18
-          run-lint: true
       - go-test:
           name: Go 1.17
           docker-image: cimg/go:1.17
+          run-lint: true  # golangci-lint doesn't yet work in Go 1.18
       - go-test:
           name: Go 1.16
           docker-image: cimg/go:1.16

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,18 +4,15 @@ workflows:
   workflow:
     jobs:
       - go-test:
+          name: Go 1.18
+          docker-image: cimg/go:1.18
+          run-lint: true
+      - go-test:
           name: Go 1.17
           docker-image: cimg/go:1.17
-          run-lint: true
       - go-test:
           name: Go 1.16
           docker-image: cimg/go:1.16
-      - go-test:
-          name: Go 1.15
-          docker-image: cimg/go:1.15
-      - go-test:
-          name: Go 1.14
-          docker-image: cimg/go:1.14
       - benchmarks
 
 jobs:
@@ -92,7 +89,7 @@ jobs:
 
   benchmarks:
     docker:
-      - image: cimg/go:1.16
+      - image: cimg/go:1.18
         environment:
           CIRCLE_ARTIFACTS: /tmp/circle-artifacts
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       
       - run:
           name: install go-junit-report
-          command: go get -u github.com/jstemmer/go-junit-report
+          command: go install github.com/jstemmer/go-junit-report@latest
       
       - run:
           name: build (default implementation)

--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -2,13 +2,14 @@ version: 2
 
 jobs:
   - docker:
-      image: golang:1.14-buster
+      image: golang:1.16-buster
     template:
       name: go
     env:
       LD_RELEASE_GO_IMPORT_PATH: gopkg.in/launchdarkly/go-jsonstream.v1
 
 branches:
+  - name: v2
   - name: v1
 
 publications:

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ benchmark-allocs:
 
 $(LINTER_VERSION_FILE):
 	rm -f $(LINTER)
-	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s $(GOLANGCI_LINT_VERSION)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s $(GOLANGCI_LINT_VERSION)
 	touch $(LINTER_VERSION_FILE)
 
 lint: $(LINTER_VERSION_FILE)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module gopkg.in/launchdarkly/go-jsonstream.v1
+module github.com/launchdarkly/go-jsonstream/v2
 
-go 1.14
+go 1.16
 
 require (
 	github.com/mailru/easyjson v0.7.6

--- a/jreader/json_unmarshal_comparative_benchmark_test.go
+++ b/jreader/json_unmarshal_comparative_benchmark_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"gopkg.in/launchdarkly/go-jsonstream.v1/internal/commontest"
+	"github.com/launchdarkly/go-jsonstream/v2/internal/commontest"
 )
 
 // These benchmarks perform equivalent actions to the ones in reader_benchmark_test.go, but using

--- a/jreader/reader_benchmark_test.go
+++ b/jreader/reader_benchmark_test.go
@@ -3,7 +3,7 @@ package jreader
 import (
 	"testing"
 
-	"gopkg.in/launchdarkly/go-jsonstream.v1/internal/commontest"
+	"github.com/launchdarkly/go-jsonstream/v2/internal/commontest"
 )
 
 func BenchmarkReadNullNoAlloc(b *testing.B) {

--- a/jreader/reader_test.go
+++ b/jreader/reader_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"gopkg.in/launchdarkly/go-jsonstream.v1/internal/commontest"
+	"github.com/launchdarkly/go-jsonstream/v2/internal/commontest"
 
 	"github.com/stretchr/testify/require"
 )

--- a/jreader/reader_unmarshal_test.go
+++ b/jreader/reader_unmarshal_test.go
@@ -3,7 +3,7 @@ package jreader
 import (
 	"testing"
 
-	"gopkg.in/launchdarkly/go-jsonstream.v1/internal/commontest"
+	"github.com/launchdarkly/go-jsonstream/v2/internal/commontest"
 
 	"github.com/stretchr/testify/require"
 )

--- a/jreader/testdata_test.go
+++ b/jreader/testdata_test.go
@@ -1,7 +1,7 @@
 package jreader
 
 import (
-	"gopkg.in/launchdarkly/go-jsonstream.v1/internal/commontest"
+	"github.com/launchdarkly/go-jsonstream/v2/internal/commontest"
 )
 
 // ExampleStruct is defined in another package, so we need to wrap it in our own type to define methods on it.

--- a/jreader/token_reader_test.go
+++ b/jreader/token_reader_test.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"testing"
 
-	"gopkg.in/launchdarkly/go-jsonstream.v1/internal/commontest"
+	"github.com/launchdarkly/go-jsonstream/v2/internal/commontest"
 )
 
 // This uses the framework defined in ReaderTestSuite to exercise any TokenReader implementation

--- a/jwriter/json_marshal_comparative_benchmark_test.go
+++ b/jwriter/json_marshal_comparative_benchmark_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"gopkg.in/launchdarkly/go-jsonstream.v1/internal/commontest"
+	"github.com/launchdarkly/go-jsonstream/v2/internal/commontest"
 )
 
 // These benchmarks perform equivalent actions to the ones in writer_benchmark_test.go, but using

--- a/jwriter/testdata_test.go
+++ b/jwriter/testdata_test.go
@@ -1,7 +1,7 @@
 package jwriter
 
 import (
-	"gopkg.in/launchdarkly/go-jsonstream.v1/internal/commontest"
+	"github.com/launchdarkly/go-jsonstream/v2/internal/commontest"
 )
 
 // ExampleStruct is defined in another package, so we need to wrap it in our own type to define methods on it.

--- a/jwriter/token_writer_test.go
+++ b/jwriter/token_writer_test.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"testing"
 
-	"gopkg.in/launchdarkly/go-jsonstream.v1/internal/commontest"
+	"github.com/launchdarkly/go-jsonstream/v2/internal/commontest"
 )
 
 // This uses the framework defined in WriterTestSuite to exercise any TokenWriter implementation

--- a/jwriter/writer_benchmark_test.go
+++ b/jwriter/writer_benchmark_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"testing"
 
-	"gopkg.in/launchdarkly/go-jsonstream.v1/internal/commontest"
+	"github.com/launchdarkly/go-jsonstream/v2/internal/commontest"
 )
 
 func BenchmarkWriteNull(b *testing.B) {

--- a/jwriter/writer_marshal_test.go
+++ b/jwriter/writer_marshal_test.go
@@ -3,7 +3,7 @@ package jwriter
 import (
 	"testing"
 
-	"gopkg.in/launchdarkly/go-jsonstream.v1/internal/commontest"
+	"github.com/launchdarkly/go-jsonstream/v2/internal/commontest"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/jwriter/writer_test.go
+++ b/jwriter/writer_test.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"testing"
 
-	"gopkg.in/launchdarkly/go-jsonstream.v1/internal/commontest"
+	"github.com/launchdarkly/go-jsonstream/v2/internal/commontest"
 )
 
 // This uses the framework defined in the commontest package to exercise Writer with a large


### PR DESCRIPTION
There are no code changes, so the only reason for releasing a 2.x major version is to switch the import path— which is worth doing for consistency and to avoid depending on a third-party service. While we're doing so, we may as well update the minimum Go version.

Note, even though technically only the last _two_ Go versions are supported, I've put the minimum at 1.16 rather than 1.17, because 1.18 has only been in GA for a short time.