### PR TITLE
eliminate garbage when `SkipValue` encounters strings

### DIFF
--- a/jreader/reader.go
+++ b/jreader/reader.go
@@ -335,11 +335,15 @@ func (r *Reader) tryObject(allowNull bool) ObjectState {
 // If there is a parsing error, the return value is the same as for a null and the Reader enters
 // a failed state, which you can detect with Error().
 func (r *Reader) Any() AnyValue {
+	return r.any(false)
+}
+
+func (r *Reader) any(ignoreString bool) AnyValue {
 	r.awaitingReadValue = false
 	if r.err != nil {
 		return AnyValue{}
 	}
-	v, err := r.tr.Any()
+	v, err := r.tr.any(ignoreString)
 	if err != nil {
 		r.err = err
 		return AnyValue{}
@@ -367,7 +371,7 @@ func (r *Reader) SkipValue() error {
 	if r.err != nil {
 		return r.err
 	}
-	v := r.Any()
+	v := r.any(true)
 	if v.Kind == ArrayValue {
 		for v.Array.Next() {
 		}

--- a/jreader/token_reader_default.go
+++ b/jreader/token_reader_default.go
@@ -17,6 +17,10 @@ import (
 	"unicode/utf8"
 )
 
+// isEasyJSON is used in tests to e.g. expect different allocation behavior depending
+// on which backend is in use.
+const isEasyJSON = false
+
 var (
 	tokenNull  = []byte("null")  //nolint:gochecknoglobals
 	tokenTrue  = []byte("true")  //nolint:gochecknoglobals
@@ -245,6 +249,10 @@ func badArrayOrObjectItemMessage(isObject bool) string {
 // returns an error. Unlike Reader.Any(), for array and object values it does not create an
 // ArrayState or ObjectState.
 func (r *tokenReader) Any() (AnyValue, error) {
+	return r.any(false)
+}
+
+func (r *tokenReader) any(ignoreString bool) (AnyValue, error) {
 	t, err := r.next()
 	if err != nil {
 		return AnyValue{}, err
@@ -255,7 +263,11 @@ func (r *tokenReader) Any() (AnyValue, error) {
 	case numberToken:
 		return AnyValue{Kind: NumberValue, Number: t.numberValue}, nil
 	case stringToken:
-		return AnyValue{Kind: StringValue, String: string(t.stringValue)}, nil
+		var s string
+		if !ignoreString {
+			s = string(t.stringValue)
+		}
+		return AnyValue{Kind: StringValue, String: s}, nil
 	case delimiterToken:
 		if t.delimiter == '[' {
 			return AnyValue{Kind: ArrayValue}, nil

--- a/jreader/token_reader_easyjson.go
+++ b/jreader/token_reader_easyjson.go
@@ -16,6 +16,10 @@ import (
 	"github.com/mailru/easyjson/jlexer"
 )
 
+// isEasyJSON is used in tests to e.g. expect different allocation behavior depending
+// on which backend is in use.
+const isEasyJSON = true
+
 type tokenReader struct {
 	// We might be initialized either with a pointer to an existing Lexer, in which case we'll use that.
 	pLexer *jlexer.Lexer
@@ -165,6 +169,13 @@ func (tr *tokenReader) EndDelimiterOrComma(delim byte) (bool, error) {
 }
 
 func (tr *tokenReader) Any() (AnyValue, error) {
+	return tr.any(false)
+}
+
+// any is provided for compatability with the non-easyjson tokenReader API --
+// the parameter is ignored, because easyjson doesn't provide an easy way to
+// avoid a string heap allocation when calling lexer.Interface().
+func (tr *tokenReader) any(_ bool) (AnyValue, error) {
 	pLexer := tr.pLexer
 	if pLexer == nil {
 		pLexer = &tr.inlineLexer


### PR DESCRIPTION
Thanks for the great library!  When using this to parse a large (10+MB) amount of JSON, we see a significant (the majority! after https://github.com/launchdarkly/go-jsonstream/pull/19 ) amount of garbage created when `ObjectState.Next()` calls `Reader.SkipValue()`:
<img width="350" alt="image" src="https://github.com/launchdarkly/go-jsonstream/assets/35409959/77f036c7-b87d-4867-ac0b-0167c8b538cd">

With this PR an internal benchmark shows an 80% reduction in allocation count (with a more modest reduction in MB allocated, although a majority of the remaining allocs are just the JSON file contents we are operating on):

```
name             old time/op    new time/op    delta
LoadFromFile-10     108ms ± 1%     106ms ± 1%   -1.16%  (p=0.008 n=5+5)

name             old alloc/op   new alloc/op   delta
LoadFromFile-10    26.0MB ± 0%    24.9MB ± 0%   -3.90%  (p=0.008 n=5+5)

name             old allocs/op  new allocs/op  delta
LoadFromFile-10     34.0k ± 0%      5.8k ± 0%  -82.80%  (p=0.029 n=4+4)
```

I've added a test as well that fails without this change applied, and with this change applied shows that streaming over an object with string values is 0 allocation.

Happy to iterate if you have feedback!