### PR TITLE
jreader: add StringAsBytes()

### DIFF
--- a/jreader/reader.go
+++ b/jreader/reader.go
@@ -176,14 +176,25 @@ func (r *Reader) Float64OrNull() (float64, bool) {
 // the Reader enters a failed state, which you can detect with Error(). Types other than string
 // are never converted to strings.
 func (r *Reader) String() string {
+	return string(r.StringAsBytes())
+}
+
+// StringAsBytes attempts to read a string value, returning a byte slice that indexes into the
+// original JSON bytes.  This method can be used instead of String to avoid garbage creation,
+// but care must be taken to avoid modifying the returned byte slice.
+//
+// If there is a parsing error, or the next value is not a string, the return value is nil and
+// the Reader enters a failed state, which you can detect with Error(). Types other than string
+// are never converted to strings.
+func (r *Reader) StringAsBytes() []byte {
 	r.awaitingReadValue = false
 	if r.err != nil {
-		return ""
+		return nil
 	}
-	val, err := r.tr.String()
+	val, err := r.tr.StringAsBytes()
 	if err != nil {
 		r.err = err
-		return ""
+		return nil
 	}
 	return val
 }

--- a/jreader/token_reader_default.go
+++ b/jreader/token_reader_default.go
@@ -146,8 +146,17 @@ func (r *tokenReader) Number() (float64, error) {
 //
 // This and all other tokenReader methods skip transparently past whitespace between tokens.
 func (r *tokenReader) String() (string, error) {
+	stringValue, err := r.StringAsBytes()
+	return string(stringValue), err
+}
+
+// StringAsBytes requires that the next token is a JSON string, returning its value if successful (consuming
+// the token), or an error if the next token is anything other than a JSON string.
+//
+// This and all other tokenReader methods skip transparently past whitespace between tokens.
+func (r *tokenReader) StringAsBytes() ([]byte, error) {
 	t, err := r.consumeScalar(stringToken)
-	return string(t.stringValue), err
+	return t.stringValue, err
 }
 
 // PropertyName requires that the next token is a JSON string and the token after that is a colon,


### PR DESCRIPTION
When reading a new version of a large but shallow JSON file from disk (e.g. an array of feature flag definitions), we end up creating a lot of strings for object properties (e.g. FF name), just to end up eventually comparing those strings to the same properties on an already-read-in older version of a flag, and discarding the newly created ones.  Exposing `StringAsBytes()` as an alternative API to `String()` enables us to compare new versions of flags (at Stripe we use a pre-existing, internal fork of a feature flag library called [`goforit`](https://github.com/stripe/goforit) to old ones without creating garbage, as due to quirks of our distribution mechanism the majority of flags rarely change.

Using `go-jsonstream` with this change (together with https://github.com/launchdarkly/go-jsonstream/pull/18 , but this PR is the most impactful) results in a 60% reduction in runtime in my usecase (updating our feature flags from disk) compared to using `encoding/json`, an 80% reduction in MB allocated, and a 99%(!) reduction in objects allocated.