### PR TITLE
feat: add StringAsBytes() method and reduce garbage when SkipValue encounters string

### DIFF
--- a/jreader/reader.go
+++ b/jreader/reader.go
@@ -176,14 +176,25 @@ func (r *Reader) Float64OrNull() (float64, bool) {
 // the Reader enters a failed state, which you can detect with Error(). Types other than string
 // are never converted to strings.
 func (r *Reader) String() string {
+	return string(r.StringAsBytes())
+}
+
+// StringAsBytes attempts to read a string value, returning a byte slice that indexes into the
+// original JSON bytes.  This method can be used instead of String to avoid garbage creation,
+// but care must be taken to avoid modifying the returned byte slice.
+//
+// If there is a parsing error, or the next value is not a string, the return value is nil and
+// the Reader enters a failed state, which you can detect with Error(). Types other than string
+// are never converted to strings.
+func (r *Reader) StringAsBytes() []byte {
 	r.awaitingReadValue = false
 	if r.err != nil {
-		return ""
+		return nil
 	}
-	val, err := r.tr.String()
+	val, err := r.tr.StringAsBytes()
 	if err != nil {
 		r.err = err
-		return ""
+		return nil
 	}
 	return val
 }

--- a/jreader/reader.go
+++ b/jreader/reader.go
@@ -170,35 +170,6 @@ func (r *Reader) Float64OrNull() (float64, bool) {
 	return val, true
 }
 
-// String attempts to read a string value.
-//
-// If there is a parsing error, or the next value is not a string, the return value is "" and
-// the Reader enters a failed state, which you can detect with Error(). Types other than string
-// are never converted to strings.
-func (r *Reader) String() string {
-	return string(r.StringAsBytes())
-}
-
-// StringAsBytes attempts to read a string value, returning a byte slice that indexes into the
-// original JSON bytes.  This method can be used instead of String to avoid garbage creation,
-// but care must be taken to avoid modifying the returned byte slice.
-//
-// If there is a parsing error, or the next value is not a string, the return value is nil and
-// the Reader enters a failed state, which you can detect with Error(). Types other than string
-// are never converted to strings.
-func (r *Reader) StringAsBytes() []byte {
-	r.awaitingReadValue = false
-	if r.err != nil {
-		return nil
-	}
-	val, err := r.tr.StringAsBytes()
-	if err != nil {
-		r.err = err
-		return nil
-	}
-	return val
-}
-
 // StringOrNull attempts to read either a string value or a null. In the case of a string, the
 // return values are (value, true); for a null, they are ("", false).
 //

--- a/jreader/reader.go
+++ b/jreader/reader.go
@@ -335,11 +335,15 @@ func (r *Reader) tryObject(allowNull bool) ObjectState {
 // If there is a parsing error, the return value is the same as for a null and the Reader enters
 // a failed state, which you can detect with Error().
 func (r *Reader) Any() AnyValue {
+	return r.any(false)
+}
+
+func (r *Reader) any(ignoreString bool) AnyValue {
 	r.awaitingReadValue = false
 	if r.err != nil {
 		return AnyValue{}
 	}
-	v, err := r.tr.Any()
+	v, err := r.tr.any(ignoreString)
 	if err != nil {
 		r.err = err
 		return AnyValue{}
@@ -367,7 +371,7 @@ func (r *Reader) SkipValue() error {
 	if r.err != nil {
 		return r.err
 	}
-	v := r.Any()
+	v := r.any(true)
 	if v.Kind == ArrayValue {
 		for v.Array.Next() {
 		}

--- a/jreader/reader_default.go
+++ b/jreader/reader_default.go
@@ -1,0 +1,33 @@
+//go:build !launchdarkly_easyjson
+// +build !launchdarkly_easyjson
+
+package jreader
+
+// String attempts to read a string value.
+//
+// If there is a parsing error, or the next value is not a string, the return value is "" and
+// the Reader enters a failed state, which you can detect with Error(). Types other than string
+// are never converted to strings.
+func (r *Reader) String() string {
+	return string(r.StringAsBytes())
+}
+
+// StringAsBytes attempts to read a string value, returning a byte slice that indexes into the
+// original JSON bytes.  This method can be used instead of String to avoid garbage creation,
+// but care must be taken to avoid modifying the returned byte slice.
+//
+// If there is a parsing error, or the next value is not a string, the return value is nil and
+// the Reader enters a failed state, which you can detect with Error(). Types other than string
+// are never converted to strings.
+func (r *Reader) StringAsBytes() []byte {
+	r.awaitingReadValue = false
+	if r.err != nil {
+		return nil
+	}
+	val, err := r.tr.StringAsBytes()
+	if err != nil {
+		r.err = err
+		return nil
+	}
+	return val
+}

--- a/jreader/reader_easyjson.go
+++ b/jreader/reader_easyjson.go
@@ -1,0 +1,31 @@
+//go:build launchdarkly_easyjson
+// +build launchdarkly_easyjson
+
+package jreader
+
+// String attempts to read a string value.
+//
+// If there is a parsing error, or the next value is not a string, the return value is "" and
+// the Reader enters a failed state, which you can detect with Error(). Types other than string
+// are never converted to strings.
+func (r *Reader) String() string {
+	r.awaitingReadValue = false
+	if r.err != nil {
+		return ""
+	}
+	val, err := r.tr.String()
+	if err != nil {
+		r.err = err
+		return ""
+	}
+	return val
+}
+
+// StringAsBytes attempts to read a string value, returning the string as a byte slice.
+//
+// If there is a parsing error, or the next value is not a string, the return value is nil and
+// the Reader enters a failed state, which you can detect with Error(). Types other than string
+// are never converted to strings.
+func (r *Reader) StringAsBytes() []byte {
+	return []byte(r.String())
+}

--- a/jreader/token_reader_default.go
+++ b/jreader/token_reader_default.go
@@ -146,8 +146,17 @@ func (r *tokenReader) Number() (float64, error) {
 //
 // This and all other tokenReader methods skip transparently past whitespace between tokens.
 func (r *tokenReader) String() (string, error) {
+	stringValue, err := r.StringAsBytes()
+	return string(stringValue), err
+}
+
+// StringAsBytes requires that the next token is a JSON string, returning its value if successful (consuming
+// the token), or an error if the next token is anything other than a JSON string.
+//
+// This and all other tokenReader methods skip transparently past whitespace between tokens.
+func (r *tokenReader) StringAsBytes() ([]byte, error) {
 	t, err := r.consumeScalar(stringToken)
-	return string(t.stringValue), err
+	return t.stringValue, err
 }
 
 // PropertyName requires that the next token is a JSON string and the token after that is a colon,

--- a/jreader/token_reader_default.go
+++ b/jreader/token_reader_default.go
@@ -17,6 +17,8 @@ import (
 	"unicode/utf8"
 )
 
+const isEasyJSON = false
+
 var (
 	tokenNull  = []byte("null")  //nolint:gochecknoglobals
 	tokenTrue  = []byte("true")  //nolint:gochecknoglobals
@@ -245,6 +247,10 @@ func badArrayOrObjectItemMessage(isObject bool) string {
 // returns an error. Unlike Reader.Any(), for array and object values it does not create an
 // ArrayState or ObjectState.
 func (r *tokenReader) Any() (AnyValue, error) {
+	return r.any(false)
+}
+
+func (r *tokenReader) any(ignoreString bool) (AnyValue, error) {
 	t, err := r.next()
 	if err != nil {
 		return AnyValue{}, err
@@ -255,7 +261,11 @@ func (r *tokenReader) Any() (AnyValue, error) {
 	case numberToken:
 		return AnyValue{Kind: NumberValue, Number: t.numberValue}, nil
 	case stringToken:
-		return AnyValue{Kind: StringValue, String: string(t.stringValue)}, nil
+		var s string
+		if !ignoreString {
+			s = string(t.stringValue)
+		}
+		return AnyValue{Kind: StringValue, String: s}, nil
 	case delimiterToken:
 		if t.delimiter == '[' {
 			return AnyValue{Kind: ArrayValue}, nil

--- a/jreader/token_reader_default.go
+++ b/jreader/token_reader_default.go
@@ -17,10 +17,6 @@ import (
 	"unicode/utf8"
 )
 
-// isEasyJSON is used in tests to e.g. expect different allocation behavior depending
-// on which backend is in use.
-const isEasyJSON = false //nolint:deadcode
-
 var (
 	tokenNull  = []byte("null")  //nolint:gochecknoglobals
 	tokenTrue  = []byte("true")  //nolint:gochecknoglobals

--- a/jreader/token_reader_default.go
+++ b/jreader/token_reader_default.go
@@ -17,7 +17,9 @@ import (
 	"unicode/utf8"
 )
 
-const isEasyJSON = false
+// isEasyJSON is used in tests to e.g. expect different allocation behavior depending
+// on which backend is in use.
+const isEasyJSON = false //nolint:deadcode
 
 var (
 	tokenNull  = []byte("null")  //nolint:gochecknoglobals

--- a/jreader/token_reader_default_test.go
+++ b/jreader/token_reader_default_test.go
@@ -1,0 +1,8 @@
+//go:build !launchdarkly_easyjson
+// +build !launchdarkly_easyjson
+
+package jreader
+
+// isEasyJSON is used in tests to e.g. expect different allocation behavior depending
+// on which backend is in use.
+const isEasyJSON = false

--- a/jreader/token_reader_easyjson.go
+++ b/jreader/token_reader_easyjson.go
@@ -16,10 +16,6 @@ import (
 	"github.com/mailru/easyjson/jlexer"
 )
 
-// isEasyJSON is used in tests to e.g. expect different allocation behavior depending
-// on which backend is in use.
-const isEasyJSON = true //nolint:deadcode
-
 type tokenReader struct {
 	// We might be initialized either with a pointer to an existing Lexer, in which case we'll use that.
 	pLexer *jlexer.Lexer

--- a/jreader/token_reader_easyjson.go
+++ b/jreader/token_reader_easyjson.go
@@ -16,6 +16,8 @@ import (
 	"github.com/mailru/easyjson/jlexer"
 )
 
+const isEasyJSON = true
+
 type tokenReader struct {
 	// We might be initialized either with a pointer to an existing Lexer, in which case we'll use that.
 	pLexer *jlexer.Lexer
@@ -165,6 +167,13 @@ func (tr *tokenReader) EndDelimiterOrComma(delim byte) (bool, error) {
 }
 
 func (tr *tokenReader) Any() (AnyValue, error) {
+	return tr.any(false)
+}
+
+// any is provided for compatability with the non-easyjson tokenReader API --
+// the parameter is ignored, because easyjson doesn't provide an easy way to
+// avoid a string heap allocation when calling lexer.Interface().
+func (tr *tokenReader) any(_ bool) (AnyValue, error) {
 	pLexer := tr.pLexer
 	if pLexer == nil {
 		pLexer = &tr.inlineLexer

--- a/jreader/token_reader_easyjson.go
+++ b/jreader/token_reader_easyjson.go
@@ -16,7 +16,9 @@ import (
 	"github.com/mailru/easyjson/jlexer"
 )
 
-const isEasyJSON = true
+// isEasyJSON is used in tests to e.g. expect different allocation behavior depending
+// on which backend is in use.
+const isEasyJSON = true //nolint:deadcode
 
 type tokenReader struct {
 	// We might be initialized either with a pointer to an existing Lexer, in which case we'll use that.

--- a/jreader/token_reader_easyjson_test.go
+++ b/jreader/token_reader_easyjson_test.go
@@ -1,0 +1,8 @@
+//go:build launchdarkly_easyjson
+// +build launchdarkly_easyjson
+
+package jreader
+
+// isEasyJSON is used in tests to e.g. expect different allocation behavior depending
+// on which backend is in use.
+const isEasyJSON = true


### PR DESCRIPTION
This PR (from contributor @bobby-stripe) adds a new `StringAsBytes()` method, which can be used instead of the always-allocating `String()` method. 

This shouldn't affect LaunchDarkly's current use as the method didn't exist before, but we may be able to take advantage of this new method if we need to optimize. 

The justification for this use-case can be found [here](https://github.com/launchdarkly/go-jsonstream/pull/19).