### PR TITLE
jreader: fix StringAsBytes

### DIFF
--- a/jreader/reader.go
+++ b/jreader/reader.go
@@ -170,35 +170,6 @@ func (r *Reader) Float64OrNull() (float64, bool) {
 	return val, true
 }
 
-// String attempts to read a string value.
-//
-// If there is a parsing error, or the next value is not a string, the return value is "" and
-// the Reader enters a failed state, which you can detect with Error(). Types other than string
-// are never converted to strings.
-func (r *Reader) String() string {
-	return string(r.StringAsBytes())
-}
-
-// StringAsBytes attempts to read a string value, returning a byte slice that indexes into the
-// original JSON bytes.  This method can be used instead of String to avoid garbage creation,
-// but care must be taken to avoid modifying the returned byte slice.
-//
-// If there is a parsing error, or the next value is not a string, the return value is nil and
-// the Reader enters a failed state, which you can detect with Error(). Types other than string
-// are never converted to strings.
-func (r *Reader) StringAsBytes() []byte {
-	r.awaitingReadValue = false
-	if r.err != nil {
-		return nil
-	}
-	val, err := r.tr.StringAsBytes()
-	if err != nil {
-		r.err = err
-		return nil
-	}
-	return val
-}
-
 // StringOrNull attempts to read either a string value or a null. In the case of a string, the
 // return values are (value, true); for a null, they are ("", false).
 //

--- a/jreader/reader_default.go
+++ b/jreader/reader_default.go
@@ -1,0 +1,33 @@
+//go:build !launchdarkly_easyjson
+// +build !launchdarkly_easyjson
+
+package jreader
+
+// String attempts to read a string value.
+//
+// If there is a parsing error, or the next value is not a string, the return value is "" and
+// the Reader enters a failed state, which you can detect with Error(). Types other than string
+// are never converted to strings.
+func (r *Reader) String() string {
+	return string(r.StringAsBytes())
+}
+
+// StringAsBytes attempts to read a string value, returning a byte slice that indexes into the
+// original JSON bytes.  This method can be used instead of String to avoid garbage creation,
+// but care must be taken to avoid modifying the returned byte slice.
+//
+// If there is a parsing error, or the next value is not a string, the return value is nil and
+// the Reader enters a failed state, which you can detect with Error(). Types other than string
+// are never converted to strings.
+func (r *Reader) StringAsBytes() []byte {
+	r.awaitingReadValue = false
+	if r.err != nil {
+		return nil
+	}
+	val, err := r.tr.StringAsBytes()
+	if err != nil {
+		r.err = err
+		return nil
+	}
+	return val
+}

--- a/jreader/reader_easyjson.go
+++ b/jreader/reader_easyjson.go
@@ -1,0 +1,31 @@
+//go:build launchdarkly_easyjson
+// +build launchdarkly_easyjson
+
+package jreader
+
+// String attempts to read a string value.
+//
+// If there is a parsing error, or the next value is not a string, the return value is "" and
+// the Reader enters a failed state, which you can detect with Error(). Types other than string
+// are never converted to strings.
+func (r *Reader) String() string {
+	r.awaitingReadValue = false
+	if r.err != nil {
+		return ""
+	}
+	val, err := r.tr.String()
+	if err != nil {
+		r.err = err
+		return ""
+	}
+	return val
+}
+
+// StringAsBytes attempts to read a string value, returning the string as a byte slice.
+//
+// If there is a parsing error, or the next value is not a string, the return value is nil and
+// the Reader enters a failed state, which you can detect with Error(). Types other than string
+// are never converted to strings.
+func (r *Reader) StringAsBytes() []byte {
+	return []byte(r.String())
+}


### PR DESCRIPTION
In the original PR with `StringAsBytes` I missed testing with easyjson.  Looking in to the implementation, there isn't a good way to get a string-as-bytes without an allocation from `easyjson` (the easyjson lexer _does_ have a `Bytes()` method, but its designed for decoding a string as base64 bytes: [link](https://github.com/mailru/easyjson/blob/v0.7.6/jlexer/lexer.go#L697)).  So while this API doesn't _help_ in the easyjson case, it isn't worse than a caller who needs bytes doing the cast on their own, and allows easy testing without code changes if just the build tags are flipped.

cc @cwaldren-ld 