### PR TITLE
jreader: address PR suggestions and fix lint build

### DIFF
--- a/jreader/token_reader_default.go
+++ b/jreader/token_reader_default.go
@@ -17,7 +17,9 @@ import (
 	"unicode/utf8"
 )
 
-const isEasyJSON = false
+// isEasyJSON is used in tests to e.g. expect different allocation behavior depending
+// on which backend is in use.
+const isEasyJSON = false //nolint:deadcode
 
 var (
 	tokenNull  = []byte("null")  //nolint:gochecknoglobals

--- a/jreader/token_reader_easyjson.go
+++ b/jreader/token_reader_easyjson.go
@@ -16,7 +16,9 @@ import (
 	"github.com/mailru/easyjson/jlexer"
 )
 
-const isEasyJSON = true
+// isEasyJSON is used in tests to e.g. expect different allocation behavior depending
+// on which backend is in use.
+const isEasyJSON = true //nolint:deadcode
 
 type tokenReader struct {
 	// We might be initialized either with a pointer to an existing Lexer, in which case we'll use that.


### PR DESCRIPTION
OK - this should be 1 final commit to merge into `contrib` to get CI to pass (I hope).  Sorry for the mess/confusion here!

The alternative to the linter "ignore" comments would be to move the `const` into 2 new `token_reader_{default,easyjson}_test.go` files, but that seems like a waste/file explosion.

cc @cwaldren-ld 