### PR TITLE
jreader: move isEasyJSON constant into test-only file to satisfy linter

### DIFF
--- a/jreader/token_reader_default.go
+++ b/jreader/token_reader_default.go
@@ -17,10 +17,6 @@ import (
 	"unicode/utf8"
 )
 
-// isEasyJSON is used in tests to e.g. expect different allocation behavior depending
-// on which backend is in use.
-const isEasyJSON = false //nolint:deadcode
-
 var (
 	tokenNull  = []byte("null")  //nolint:gochecknoglobals
 	tokenTrue  = []byte("true")  //nolint:gochecknoglobals

--- a/jreader/token_reader_default_test.go
+++ b/jreader/token_reader_default_test.go
@@ -1,0 +1,8 @@
+//go:build !launchdarkly_easyjson
+// +build !launchdarkly_easyjson
+
+package jreader
+
+// isEasyJSON is used in tests to e.g. expect different allocation behavior depending
+// on which backend is in use.
+const isEasyJSON = false

--- a/jreader/token_reader_easyjson.go
+++ b/jreader/token_reader_easyjson.go
@@ -16,10 +16,6 @@ import (
 	"github.com/mailru/easyjson/jlexer"
 )
 
-// isEasyJSON is used in tests to e.g. expect different allocation behavior depending
-// on which backend is in use.
-const isEasyJSON = true //nolint:deadcode
-
 type tokenReader struct {
 	// We might be initialized either with a pointer to an existing Lexer, in which case we'll use that.
 	pLexer *jlexer.Lexer

--- a/jreader/token_reader_easyjson_test.go
+++ b/jreader/token_reader_easyjson_test.go
@@ -1,0 +1,8 @@
+//go:build launchdarkly_easyjson
+// +build launchdarkly_easyjson
+
+package jreader
+
+// isEasyJSON is used in tests to e.g. expect different allocation behavior depending
+// on which backend is in use.
+const isEasyJSON = true


### PR DESCRIPTION
`golangci-lint run ./...` (version 1.48) now runs successfully locally, as does `make test test-easyjson` and `make all` 🤞 thanks for working with me here @cwaldren-ld !
