### PR TITLE
chore: add explicit permissions to release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

N/A — this is a CI workflow configuration change only.

**Related issues**

None.

**Describe the solution you've provided**

Adds explicit `permissions` to the `release-please` job in the GitHub Actions workflow:

```yaml
permissions:
  contents: write
  pull-requests: write
```

These permissions are required for the `release-please-action` to:
- Create and update release pull requests (`pull-requests: write`)
- Create GitHub releases and push tags (`contents: write`)

Without explicit permissions, the job relies on the repository's default `GITHUB_TOKEN` permissions, which may be insufficient if the org or repo defaults are set to read-only.

**Describe alternatives you've considered**

Setting these permissions at the workflow level (top-level `permissions` key) was considered, but job-level permissions are preferred to follow the principle of least privilege.

**Additional context**

This is part of an audit of all `launchdarkly-sdk`-tagged repositories to ensure release-please workflows have the necessary permissions configured explicitly.

**Human review checklist**
- [ ] Permissions are on the correct job (`release-please`, not a downstream publish/provenance job)

Link to Devin session: https://app.devin.ai/sessions/a83b6e4f4fa14b96b859cfb50755a2c1
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow-only change that just scopes `GITHUB_TOKEN` permissions for `release-please`; main risk is mis-scoping could prevent release PRs/tags from being created.
> 
> **Overview**
> Adds explicit job-level `permissions` to `.github/workflows/release-please.yml` so `release-please-action` can **create/update release PRs** and **publish tags/releases** even when repo/org default `GITHUB_TOKEN` permissions are read-only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35d0afd0d265a9b606ebfc33d9e2ae2abaa7c100. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->