### PR TITLE
chore: scope v4 branch workflows to v4

### DIFF
--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        branch: ["v3"]
+        branch: ["v3", "v4"]
       fail-fast: false
     env:
       officialLatestVersion: ${{ needs.check-go-eol.outputs.latest }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,11 @@
 name: Build and Test SDK
 on:
   push:
-    branches: [ 'v3', 'feat/**' ]
+    branches: [ 'v4', 'feat/**' ]
     paths-ignore:
       - '**.md' # Don't run CI on markdown changes.
   pull_request:
-    branches: [ 'v3', 'feat/**'  ]
+    branches: [ 'v4', 'feat/**'  ]
     paths-ignore:
       - '**.md'
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
-          target-branch: ${{ github.ref_name }}
+          target-branch: v4

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,7 +3,7 @@ name: Run Release Please
 on:
   push:
     branches:
-      - v3
+      - v4
   workflow_dispatch:
 
 jobs:
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
-          target-branch: v3
+          target-branch: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary

Configure the new `v4` branch's GitHub Actions workflows for the v4 release line. **This PR targets `v4` and introduces no changes to `v3`** — `v3` stays frozen at its current HEAD.

Three files change:

1. **`release-please.yml`** — trigger on push to `v4`, with `target-branch` hardcoded to `v4`. (See "Why hardcoded `v4`" below.)
2. **`ci.yml`** — `push` and `pull_request` triggers scoped to `[v4, feat/**]`. `v3` PRs/pushes read v3's `ci.yml`, so listing `v3` here on v4 would be dead config.
3. **`check-go-versions.yml`** — matrix kept at `["v3", "v4"]`. This is an **intentional cross-reference**: after the eventual default-branch flip to v4, this scheduled workflow runs from v4, and the matrix tells it to keep opening Go-version-bump PRs against both branches during v3's deprecation window.

This is one of three parallel PRs across **[`go-jsonstream`](https://github.com/launchdarkly/go-jsonstream/pull/40), [`go-sdk-common`](https://github.com/launchdarkly/go-sdk-common/pull/52), and [`go-server-sdk-evaluation`](https://github.com/launchdarkly/go-server-sdk-evaluation/pull/53)**. Same change pattern in each.

## Why this PR exists

Bundled per Matthew's feedback on the original `release-please.yml`-only revision: keeps all "set up v4 GHA" work in one PR rather than splitting across multiple. Most importantly, **without the `ci.yml` change the v4 transition PRs in the next stage would have no Go-test signal at PR time** — only the external bot checks (Bugbot, UPRA, Semgrep) would gate them.

## Why hardcoded `v4` and not omitted, and not `${{ github.ref_name }}`

An earlier revision of this PR dropped `target-branch` entirely, on the understanding that the action would auto-detect from the triggering ref. It does not — it falls back to the repo's default branch ([release-please-action#913](https://github.com/googleapis/release-please-action/issues/913), open since Dec 2023). For us today the default is `v3`, so omitting `target-branch` would silently route v4 release PRs to v3.

A later revision used `target-branch: ${{ github.ref_name }}`. That works for `push` events — restricted here to `v4` by `on.push.branches` — but `workflow_dispatch` ignores `on.push.branches`. A manual run from any branch carrying this workflow file (e.g., a feature branch forked from `v4`) would resolve `github.ref_name` to that branch and try to open a release PR against it. Hardcoded `v4` closes that gap and matches v3's existing pattern (v3's copy hardcodes `target-branch: v3`).

## Context

Part of the EasyJSON removal effort on [SDK-2113](https://launchdarkly.atlassian.net/browse/SDK-2113), shipping as v4 of these three libraries per semver. Tracked under [SDK-2119](https://launchdarkly.atlassian.net/browse/SDK-2119). Once this lands, the next step is to rebase the existing EasyJSON-removal PR (**[#39](https://github.com/launchdarkly/go-jsonstream/pull/39)**) onto `v4`.

## Test plan

- [x] YAML lints clean
- [ ] Confirmed: Go-test CI workflows are gated by `ci.yml`'s branch filter; this PR is YAML-only with no Go-code surface to validate. External checks (Bugbot, UPRA, Do Not Merge, Semgrep) still run.

via LD Research 🤖

[SDK-2113]: https://launchdarkly.atlassian.net/browse/SDK-2113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
