### PR TITLE
feat: Add Reader.RawValue for capturing a value's raw bytes

### DIFF
--- a/jreader/errors.go
+++ b/jreader/errors.go
@@ -13,6 +13,7 @@ const (
 	errMsgExpectedColon    = "expected colon after property name"
 	errMsgInvalidNumber    = "invalid numeric value"
 	errMsgInvalidString    = "unterminated or invalid string value"
+	errMsgInvalidValue     = "invalid JSON value"
 	errMsgUnexpectedChar   = "unexpected character"
 	errMsgUnexpectedSymbol = "unexpected symbol"
 )

--- a/jreader/reader_default.go
+++ b/jreader/reader_default.go
@@ -31,3 +31,50 @@ func (r *Reader) StringAsBytes() []byte {
 	}
 	return val
 }
+
+// RawValue consumes the next JSON value of any type and returns its raw bytes verbatim. For an
+// array or object value, this includes everything up to and including the matching close
+// delimiter. The returned slice references the Reader's input data and is valid only as long as
+// the input is; it must not be modified.
+//
+// The value is fully validated, so malformed JSON produces a parsing error rather than being
+// returned. Scalars are validated by the tokenizer, whose grammar is RFC 8259 compliant. For an
+// array or object, the byte boundary is located by scanning to the matching close delimiter and
+// the captured bytes are then checked with encoding/json, since the boundary scan does not
+// interpret the content in between.
+//
+// If there is a parsing error, or there is no next value, the return value is nil and the Reader
+// enters a failed state, which you can detect with Error().
+//
+// This method is not available when building with the launchdarkly_easyjson tag: easyjson
+// support is planned for removal, so no new functionality is provided for it.
+func (r *Reader) RawValue() []byte {
+	r.awaitingReadValue = false
+	if r.err != nil {
+		return nil
+	}
+	val, err := r.tr.RawValue()
+	if err != nil {
+		r.err = err
+		return nil
+	}
+	return val
+}
+
+// Offset returns the Reader's current byte offset within its original input: the position of
+// the next byte that will be consumed, or, if a token has been read ahead and pushed back, the
+// position where that token starts.
+//
+// Its primary use is capturing the raw bytes of a value that is parsed in place, without the
+// separate boundary scan and validation pass that RawValue performs: record Offset before and
+// after parsing the value, then slice the original input. Since the tokenizer fully validates
+// everything it parses, the captured span is known-valid JSON. The offset may point at
+// whitespace preceding the next token (and, after a value, at whitespace that was skipped before
+// a following token was read ahead), so callers capturing a span should trim JSON whitespace
+// (space, tab, carriage return, newline) from both ends.
+//
+// This method is not available when building with the launchdarkly_easyjson tag: easyjson
+// support is planned for removal, so no new functionality is provided for it.
+func (r *Reader) Offset() int {
+	return r.tr.Offset()
+}

--- a/jreader/reader_offset_test.go
+++ b/jreader/reader_offset_test.go
@@ -1,0 +1,91 @@
+//go:build !launchdarkly_easyjson
+// +build !launchdarkly_easyjson
+
+package jreader
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Offset is provided only by the default build, like RawValue; its tests carry the same tag.
+
+const jsonWhitespace = " \t\r\n"
+
+func TestOffsetCapturesSpanAroundInPlaceParse(t *testing.T) {
+	input := []byte(`{"first":1,"obj":{"x":[1,2],"y":"z"},"last":2}`)
+	r := NewReader(input)
+	var span []byte
+	for obj := r.Object(); obj.Next(); {
+		if string(obj.Name()) != "obj" {
+			require.NoError(t, r.SkipValue())
+			continue
+		}
+		start := r.Offset()
+		require.NoError(t, r.SkipValue()) // stands in for any in-place parse of the value
+		span = input[start:r.Offset()]
+	}
+	require.NoError(t, r.Error())
+	assert.Equal(t, `{"x":[1,2],"y":"z"}`, string(bytes.Trim(span, jsonWhitespace)))
+}
+
+func TestOffsetSpanMayIncludeSurroundingWhitespace(t *testing.T) {
+	input := []byte(`{ "obj" : { "x" : 1 } , "z" : 2 }`)
+	r := NewReader(input)
+	var span []byte
+	for obj := r.Object(); obj.Next(); {
+		if string(obj.Name()) != "obj" {
+			require.NoError(t, r.SkipValue())
+			continue
+		}
+		start := r.Offset()
+		require.NoError(t, r.SkipValue())
+		span = input[start:r.Offset()]
+	}
+	require.NoError(t, r.Error())
+	// Whitespace around the value may be captured (and is trimmed by the caller); whitespace
+	// inside the value is preserved verbatim.
+	assert.Equal(t, `{ "x" : 1 }`, string(bytes.Trim(span, jsonWhitespace)))
+}
+
+func TestOffsetAtStartAndAfterWholeValue(t *testing.T) {
+	input := []byte(`  [1,2,3]`)
+	r := NewReader(input)
+	assert.Equal(t, 0, r.Offset())
+	require.NoError(t, r.SkipValue())
+	assert.Equal(t, len(input), r.Offset())
+}
+
+func TestTokenReaderOffsetWithUnreadToken(t *testing.T) {
+	// A failed Null probe pushes the token back; Offset must report the pushed-back token's
+	// starting position, not the position after it.
+	tr := newTokenReader([]byte(`  true`))
+	isNull, err := tr.Null()
+	require.NoError(t, err)
+	require.False(t, isNull)
+	assert.Equal(t, 2, tr.Offset())
+	raw, err := tr.RawValue()
+	require.NoError(t, err)
+	assert.Equal(t, `true`, string(raw))
+	assert.Equal(t, 6, tr.Offset())
+}
+
+func TestOffsetSpanIsValidJSONForEveryValueType(t *testing.T) {
+	input := []byte(`{"null":null,"bool":true,"num":-1.5,"str":"s","arr":[[]],"obj":{"a":{}}}`)
+	expected := map[string]string{
+		"null": `null`, "bool": `true`, "num": `-1.5`, "str": `"s"`, "arr": `[[]]`, "obj": `{"a":{}}`,
+	}
+	r := NewReader(input)
+	got := map[string]string{}
+	for obj := r.Object(); obj.Next(); {
+		name := string(obj.Name())
+		start := r.Offset()
+		require.NoError(t, r.SkipValue())
+		got[name] = string(bytes.Trim(input[start:r.Offset()], jsonWhitespace))
+	}
+	require.NoError(t, r.Error())
+	assert.Equal(t, expected, got)
+}

--- a/jreader/reader_raw_value_differential_test.go
+++ b/jreader/reader_raw_value_differential_test.go
@@ -1,0 +1,179 @@
+//go:build !launchdarkly_easyjson
+// +build !launchdarkly_easyjson
+
+package jreader
+
+import (
+	"bytes"
+	"encoding/json"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests validate RawValue's accept/reject decisions and captured byte-span against
+// encoding/json as an independent oracle, rather than against hardcoded expectations. The oracle
+// for the span of the first JSON value is encoding/json's streaming decoder, which trims leading
+// whitespace and stops at the end of the first value -- the same contract RawValue provides.
+
+// oracleFirstValue returns the raw bytes of the first JSON value in input (leading whitespace
+// trimmed, trailing content ignored), or ok == false if encoding/json rejects the input.
+func oracleFirstValue(input []byte) (raw []byte, ok bool) {
+	dec := json.NewDecoder(bytes.NewReader(input))
+	var rm json.RawMessage
+	if err := dec.Decode(&rm); err != nil {
+		return nil, false
+	}
+	return []byte(rm), true
+}
+
+func TestRawValueBoundaryMatchesEncodingJSON(t *testing.T) {
+	inputs := []string{
+		// scalars
+		`0`, `123`, `-456`, `3.25`, `-3.25e2`, `1e5`, `1E+5`, `0.0`, `-0`,
+		`true`, `false`, `null`,
+		`""`, `"simple"`, `"with \"escaped\" quotes"`, `"\\"`, `"\""`, `"A"`, `"multi é byte"`,
+		// scalar followed by trailing content -- the span must stop at the value boundary
+		`123 `, `123,`, `123}`, `123]`, `123   trailing`, `"x"extra`, `true false`,
+		// containers
+		`{}`, `[]`, `{"a":1}`, `[1,2,3]`,
+		`{"a":{"b":[{"c":null}]},"d":"e"}`,
+		`["nested",["arrays",{"and":"objects"}]]`,
+		`{"tricky":"a \"}\" and ] inside","escaped\"name":1}`,
+		// containers with trailing junk
+		`{}extra`, `[1,2]  trailing`, `[1,2,3]}`, `{"a":1},`,
+		// strings containing bracket-like bytes that must not confuse the scan
+		`["]"]`, `["}"]`, `{"k]":"v"}`, `{"k[":"v"}`, `["\\"]`, `["\""]`, `["a\\","b"]`,
+		// adversarial escapes: escaped backslash/quote boundaries and an escaped ']' that must
+		// stay inside the string
+		`["\\\\"]`, `["a\\"]`, `{"\\":"\\"}`, `["\u005D"]`, `["\\}"]`, `{"a":"\\","b":["\""]}`,
+		// invalid inputs -- both the oracle and RawValue must reject these
+		`["\}"]`, `["\]"]`, `[1 2]`, `{"a":}`, `[1,2,,]`, `{"a":1,}`,
+		// whitespace variations
+		`   {"a":1}   `, "\t\n [1] \n", ` "s" `,
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			want, ok := oracleFirstValue([]byte(in))
+			r := NewReader([]byte(in))
+			got := r.RawValue()
+			if !ok {
+				assert.Error(t, r.Error(), "encoding/json rejected %q but RawValue accepted %q", in, string(got))
+				return
+			}
+			require.NoError(t, r.Error(), "encoding/json accepted %q as %q but RawValue errored", in, string(want))
+			assert.Equal(t, string(want), string(got), "boundary mismatch for %q", in)
+		})
+	}
+}
+
+// A scalar whose valid prefix is itself a complete JSON value is captured up to that boundary
+// without error; the trailing garbage is surfaced later via RequireEOF, not by RawValue.
+func TestRawValueReturnsValidScalarPrefix(t *testing.T) {
+	for _, c := range []struct{ input, want string }{
+		{`1.2.3`, `1.2`},
+		{`0x1`, `0`},
+		{`123abc`, `123`},
+		{`1e5e5`, `1e5`},
+	} {
+		t.Run(c.input, func(t *testing.T) {
+			r := NewReader([]byte(c.input))
+			raw := r.RawValue()
+			require.NoError(t, r.Error(), "prefix %q wrongly rejected", c.input)
+			assert.Equal(t, c.want, string(raw))
+			assert.True(t, json.Valid(raw), "returned prefix must be valid JSON")
+			assert.Error(t, r.RequireEOF(), "trailing garbage should surface via RequireEOF")
+		})
+	}
+}
+
+// genValue builds a random JSON-encodable value up to the given nesting depth, favoring content
+// (brackets, quotes, escapes, multi-byte runes) that stresses the string-aware boundary scan.
+func genValue(rng *rand.Rand, depth int) interface{} {
+	if depth <= 0 || rng.Intn(3) == 0 {
+		switch rng.Intn(6) {
+		case 0:
+			return nil
+		case 1:
+			return rng.Intn(2) == 0
+		case 2:
+			return rng.NormFloat64() * 1000
+		case 3:
+			return rng.Intn(1000000) - 500000
+		default:
+			pool := []string{"", "a", `q"q`, `back\slash`, "]}[{", "unicode é", "tab\tnl\n", `\/`}
+			return pool[rng.Intn(len(pool))]
+		}
+	}
+	if rng.Intn(2) == 0 {
+		arr := make([]interface{}, rng.Intn(4))
+		for i := range arr {
+			arr[i] = genValue(rng, depth-1)
+		}
+		return arr
+	}
+	m := map[string]interface{}{}
+	keys := []string{"a", "b", `k"x`, "]", "}", "nested", "é"}
+	for i := 0; i < rng.Intn(4); i++ {
+		m[keys[rng.Intn(len(keys))]] = genValue(rng, depth-1)
+	}
+	return m
+}
+
+// The captured span must match encoding/json's first-value span for thousands of random values,
+// including random trailing bytes after the value, and must always be a cap==len alias.
+func TestRawValueGenerativeDifferential(t *testing.T) {
+	rng := rand.New(rand.NewSource(12345))
+	trailers := []string{"", " ", ",", "]", "}", "  junk", `"next"`, "42", "\t\n"}
+	for iter := 0; iter < 20000; iter++ {
+		canonical, err := json.Marshal(genValue(rng, 4))
+		if err != nil {
+			continue
+		}
+		input := append(append([]byte(nil), canonical...), trailers[rng.Intn(len(trailers))]...)
+
+		want, ok := oracleFirstValue(input)
+		if !ok {
+			continue // ambiguous trailing (e.g. a number run-on); skip
+		}
+		r := NewReader(append([]byte(nil), input...))
+		got := r.RawValue()
+		require.NoError(t, r.Error(), "iter %d: RawValue errored on %q (oracle=%q)", iter, string(input), string(want))
+		require.Equal(t, string(want), string(got), "iter %d: boundary mismatch input=%q", iter, string(input))
+		require.Equal(t, len(got), cap(got), "iter %d: cap!=len for %q", iter, string(input))
+	}
+}
+
+// Fuzz the number grammar with random number-ish bytes and assert three properties that together
+// rule out both invalid captures and false rejections of valid scalars.
+func TestRawValueScalarGrammarFuzz(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260728))
+	alphabet := []byte("0123456789+-.eE ")
+	for i := 0; i < 50000; i++ {
+		b := make([]byte, 1+rng.Intn(8))
+		for j := range b {
+			b[j] = alphabet[rng.Intn(len(alphabet))]
+		}
+		in := string(b)
+
+		r := NewReader([]byte(in))
+		raw := r.RawValue()
+		if r.Error() != nil {
+			continue
+		}
+		// Property A: anything returned must itself be valid JSON.
+		require.True(t, json.Valid(raw), "RawValue returned non-valid-JSON bytes %q for input %q", raw, in)
+		// Property B: the returned bytes must be a boundary-correct prefix of the trimmed input.
+		trimmed := strings.TrimLeft(in, " ")
+		require.True(t, strings.HasPrefix(trimmed, string(raw)),
+			"RawValue %q is not a prefix of trimmed input %q", raw, trimmed)
+		// Property C (no false rejection): if the whole trimmed input is a single valid scalar,
+		// RawValue must have returned exactly it.
+		if tr := strings.TrimSpace(in); tr != "" && json.Valid([]byte(tr)) && !strings.ContainsAny(tr, "{}[]") {
+			require.Equal(t, tr, string(raw), "input %q is a single valid scalar but RawValue returned %q", tr, raw)
+		}
+	}
+}

--- a/jreader/reader_raw_value_test.go
+++ b/jreader/reader_raw_value_test.go
@@ -1,0 +1,336 @@
+//go:build !launchdarkly_easyjson
+// +build !launchdarkly_easyjson
+
+package jreader
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// RawValue is provided only by the default build; the launchdarkly_easyjson build has no such
+// method (easyjson support is planned for removal, so no new functionality is provided for it).
+// All of its tests therefore carry the !launchdarkly_easyjson tag.
+
+func TestRawValueScalars(t *testing.T) {
+	for _, input := range []string{
+		`null`,
+		`true`,
+		`false`,
+		`0`,
+		`123`,
+		`-456`,
+		`3.25`,
+		`-3.25e2`,
+		`""`,
+		`"simple"`,
+		`"with \"escaped\" quotes"`,
+		`"unicode é escape"`,
+		`"multi-byte é directly"`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			r := NewReader([]byte(input))
+			raw := r.RawValue()
+			require.NoError(t, r.Error())
+			assert.Equal(t, input, string(raw))
+			assert.NoError(t, r.RequireEOF())
+		})
+	}
+}
+
+func TestRawValueContainers(t *testing.T) {
+	for _, input := range []string{
+		`{}`,
+		`[]`,
+		`{"a":1}`,
+		`[1,2,3]`,
+		`{"a":{"b":[{"c":null}]},"d":"e"}`,
+		`["nested",["arrays",{"and":"objects"}]]`,
+		`{"tricky":"a \"}\" and ] inside a string","escaped\"name":1}`,
+		`{ "spaced" : [ 1 , 2 ] }`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			r := NewReader([]byte(input))
+			raw := r.RawValue()
+			require.NoError(t, r.Error())
+			assert.Equal(t, input, string(raw))
+			assert.NoError(t, r.RequireEOF())
+		})
+	}
+}
+
+func TestRawValueSkipsLeadingWhitespaceAndLeavesTrailingInput(t *testing.T) {
+	r := NewReader([]byte(`   {"a":1}   `))
+	raw := r.RawValue()
+	require.NoError(t, r.Error())
+	assert.Equal(t, `{"a":1}`, string(raw))
+	assert.NoError(t, r.RequireEOF())
+}
+
+func TestRawValueWithinObjectIteration(t *testing.T) {
+	input := `{"first":true,"raw":{"x":[1,2],"y":"z"},"last":3}`
+	r := NewReader([]byte(input))
+	var raw []byte
+	var first bool
+	var last float64
+	for obj := r.Object(); obj.Next(); {
+		switch string(obj.Name()) {
+		case "first":
+			first = r.Bool()
+		case "raw":
+			raw = r.RawValue()
+		case "last":
+			last = r.Float64()
+		}
+	}
+	require.NoError(t, r.Error())
+	assert.True(t, first)
+	assert.Equal(t, `{"x":[1,2],"y":"z"}`, string(raw))
+	assert.Equal(t, float64(3), last)
+	assert.NoError(t, r.RequireEOF())
+}
+
+func TestRawValueWithinArrayIteration(t *testing.T) {
+	input := `[10,{"a":"b"},[true],20]`
+	r := NewReader([]byte(input))
+	var values []string
+	for arr := r.Array(); arr.Next(); {
+		values = append(values, string(r.RawValue()))
+	}
+	require.NoError(t, r.Error())
+	assert.Equal(t, []string{`10`, `{"a":"b"}`, `[true]`, `20`}, values)
+	assert.NoError(t, r.RequireEOF())
+}
+
+func TestRawValueEveryValueTypeWithinObjectIteration(t *testing.T) {
+	input := `{"null":null,"bool":true,"num":-1.5,"str":"s","arr":[],"obj":{}}`
+	expected := map[string]string{
+		"null": `null`, "bool": `true`, "num": `-1.5`, "str": `"s"`, "arr": `[]`, "obj": `{}`,
+	}
+	r := NewReader([]byte(input))
+	got := map[string]string{}
+	for obj := r.Object(); obj.Next(); {
+		got[string(obj.Name())] = string(r.RawValue())
+	}
+	require.NoError(t, r.Error())
+	assert.Equal(t, expected, got)
+}
+
+func TestRawValueRoundTripsThroughReader(t *testing.T) {
+	input := `{"a":[1,{"b":"c \" d"}],"e":null}`
+	r := NewReader([]byte(input))
+	raw := r.RawValue()
+	require.NoError(t, r.Error())
+
+	// The captured bytes must themselves be a complete, parseable JSON value.
+	r2 := NewReader(raw)
+	require.NoError(t, r2.SkipValue())
+	require.NoError(t, r2.Error())
+	assert.NoError(t, r2.RequireEOF())
+}
+
+func TestRawValueOnEmptyInputReturnsError(t *testing.T) {
+	r := NewReader(nil)
+	raw := r.RawValue()
+	assert.Nil(t, raw)
+	assert.Error(t, r.Error())
+}
+
+func TestRawValueOnTruncatedContainerReturnsError(t *testing.T) {
+	for _, input := range []string{
+		`{"a":`,
+		`{"a":1`,
+		`[1,2`,
+		`{"a":"unterminated`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			r := NewReader([]byte(input))
+			_ = r.RawValue()
+			assert.Error(t, r.Error())
+		})
+	}
+}
+
+func TestRawValueAfterPreviousErrorReturnsNil(t *testing.T) {
+	r := NewReader([]byte(`{"a":1}`))
+	r.AddError(SyntaxError{Message: "sorry"})
+	assert.Nil(t, r.RawValue())
+	assert.Error(t, r.Error())
+}
+
+// Containers with mismatched bracket kinds must be rejected rather than captured as truncated or
+// structurally broken bytes.
+func TestRawValueRejectsMalformedContainer(t *testing.T) {
+	for _, input := range []string{
+		`{"a":1]`,
+		`[1,2}`,
+		`{"a":[1}]`,
+		`[}]`,
+		`{"a":]}`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			r := NewReader([]byte(input))
+			_ = r.RawValue()
+			assert.Error(t, r.Error())
+		})
+	}
+}
+
+// The captured bytes must be a zero-copy view into the input, not a copy. Downstream relaying (the
+// FDv2 use case) depends on this, and the returned slice must have cap == len so a caller that
+// appends to or reslices it cannot reach adjacent bytes of the input buffer.
+func TestRawValueAliasesInputWithoutExtraCapacity(t *testing.T) {
+	for _, input := range []string{`{"a":1}`, `[1,2,3]`, `"scalar"`, `12345`} {
+		t.Run(input, func(t *testing.T) {
+			buf := []byte(input)
+			r := NewReader(buf)
+			raw := r.RawValue()
+			require.NoError(t, r.Error())
+			require.NotEmpty(t, raw)
+
+			assert.Equal(t, len(raw), cap(raw), "cap must equal len")
+
+			// Mutating the input must be visible through raw, proving they share a backing array.
+			buf[0] = 'Z'
+			assert.Equal(t, byte('Z'), raw[0], "raw must alias the input buffer")
+		})
+	}
+}
+
+// Nesting deeper than the scanner's inline capacity must round-trip exactly.
+func TestRawValueDeepNesting(t *testing.T) {
+	const depth = 40
+	input := strings.Repeat("[", depth) + strings.Repeat("]", depth)
+	r := NewReader([]byte(input))
+	raw := r.RawValue()
+	require.NoError(t, r.Error())
+	assert.Equal(t, input, string(raw))
+	assert.NoError(t, r.RequireEOF())
+}
+
+// A captured array or object is fully validated with encoding/json, so structurally bracketed
+// but otherwise malformed content is rejected.
+func TestRawValueRejectsInvalidContainerContent(t *testing.T) {
+	for _, input := range []string{
+		`[1 2]`,
+		`{"a":}`,
+		`[1,2,,,]`,
+		`{"a" "b"}`,
+		`{"a":1,}`,
+		`["\x"]`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			r := NewReader([]byte(input))
+			_ = r.RawValue()
+			assert.Error(t, r.Error())
+		})
+	}
+}
+
+func TestRawValueRejectsNonValueDelimiter(t *testing.T) {
+	for _, input := range []string{
+		`}`,
+		`]`,
+		`,`,
+		`:`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			r := NewReader([]byte(input))
+			_ = r.RawValue()
+			assert.Error(t, r.Error())
+		})
+	}
+}
+
+func TestRawValueRejectsMalformedScalar(t *testing.T) {
+	for _, input := range []string{
+		`tru`,
+		`nul`,
+		`-`,
+		`1e`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			r := NewReader([]byte(input))
+			_ = r.RawValue()
+			assert.Error(t, r.Error())
+		})
+	}
+}
+
+// Numbers that are not valid standalone JSON (leading zeros, a trailing decimal point, an empty
+// exponent) must be rejected. The RFC 8259 compliant tokenizer rejects these itself; this test
+// pins the RawValue-level guarantee regardless of which layer enforces it.
+func TestRawValueRejectsScalarInvalidAsJSON(t *testing.T) {
+	for _, input := range []string{
+		`01`,
+		`00`,
+		`007`,
+		`-0123`,
+		`1.`,
+		`1.e5`,
+		`-.5`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			r := NewReader([]byte(input))
+			raw := r.RawValue()
+			assert.Nil(t, raw)
+			assert.Error(t, r.Error())
+		})
+	}
+}
+
+// An invalid scalar can never enter the unread-token state, because the RFC 8259 compliant
+// tokenizer rejects it at the initial probe; the rejection happens no later than the first
+// attempt to read the token.
+func TestRawValueRejectsScalarInvalidAsJSONAfterUnread(t *testing.T) {
+	for _, input := range []string{
+		`01`,
+		`1.`,
+		`1.e5`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			tr := newTokenReader([]byte(input))
+			_, err := tr.Null()
+			if err == nil {
+				_, err = tr.RawValue()
+			}
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestTokenReaderRawValueAfterUnreadToken(t *testing.T) {
+	// Probing the tokenizer with Null() parses the next token and pushes it back when it is not
+	// a null, so RawValue must handle the unread-token state for every value type.
+	for _, input := range []string{
+		`true`,
+		`123`,
+		`"str"`,
+		`{"a":[1,2]}`,
+		`[{"b":"c"}]`,
+	} {
+		t.Run(input, func(t *testing.T) {
+			tr := newTokenReader([]byte(input))
+			isNull, err := tr.Null()
+			require.NoError(t, err)
+			require.False(t, isNull)
+			raw, err := tr.RawValue()
+			require.NoError(t, err)
+			assert.Equal(t, input, string(raw))
+			assert.True(t, tr.EOF())
+		})
+	}
+}
+
+func TestTokenReaderRawValueAfterUnreadNonValueDelimiterReturnsError(t *testing.T) {
+	// A failed Delimiter probe leaves the mismatched delimiter token unread.
+	tr := newTokenReader([]byte(`}`))
+	gotDelim, err := tr.Delimiter(']')
+	require.NoError(t, err)
+	require.False(t, gotDelim)
+	_, err = tr.RawValue()
+	assert.Error(t, err)
+}

--- a/jreader/token_reader_default.go
+++ b/jreader/token_reader_default.go
@@ -11,6 +11,7 @@ package jreader
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"strconv"
 	"unicode"
@@ -90,6 +91,12 @@ func (r *tokenReader) EOF() bool {
 	}
 	r.unreadByte()
 	return false
+}
+
+// Offset returns the byte offset of the next byte the tokenizer will consume, or, if a token has
+// been read ahead and pushed back, the offset where that token starts.
+func (r *tokenReader) Offset() int {
+	return r.getPos()
 }
 
 // LastPos returns the byte offset within the input where we most recently started parsing a token.
@@ -285,6 +292,123 @@ func (r *tokenReader) any(ignoreString bool) (AnyValue, error) {
 			SyntaxError{Message: errMsgUnexpectedChar, Value: string(t.delimiter), Offset: r.lastPos}
 	default:
 		return AnyValue{Kind: NullValue}, nil
+	}
+}
+
+// RawValue consumes the next JSON value of any type and returns its raw bytes verbatim as a
+// slice of the original input. The value is validated--scalars and containers alike--so malformed
+// JSON produces an error rather than being returned. Scalars are fully validated by the
+// tokenizer, whose grammar is RFC 8259 compliant; containers are boundary-scanned and then
+// checked with encoding/json.Valid, since the boundary scan does not interpret the content in
+// between.
+//
+// This and all other tokenReader methods skip transparently past whitespace between tokens.
+func (r *tokenReader) RawValue() ([]byte, error) {
+	if r.hasUnread {
+		t := r.unreadToken
+		r.hasUnread = false
+		start := r.lastPos
+		if t.kind != delimiterToken {
+			// The token was already parsed and consumed from the input, so its bytes span from
+			// where it started to the current read position.
+			return r.rawScalar(start)
+		}
+		if t.delimiter == '{' || t.delimiter == '[' {
+			return r.rawContainer(t.delimiter, start)
+		}
+		return nil, SyntaxError{Message: errMsgUnexpectedChar, Value: string(t.delimiter), Offset: start}
+	}
+	b, ok := r.skipWhitespaceAndReadByte()
+	if !ok {
+		return nil, io.EOF
+	}
+	start := r.lastPos
+	if b == '{' || b == '[' {
+		return r.rawContainer(b, start)
+	}
+	r.unreadByte()
+	t, err := r.next()
+	if err != nil {
+		return nil, err
+	}
+	if t.kind == delimiterToken {
+		// The open delimiters were handled above, so this is a close delimiter, colon, or comma--
+		// not a value.
+		return nil, SyntaxError{Message: errMsgUnexpectedChar, Value: string(t.delimiter), Offset: start}
+	}
+	return r.rawScalar(start)
+}
+
+// rawScalar returns the already-tokenized scalar spanning from start to the current read
+// position. No further check is needed: the tokenizer's grammar is RFC 8259 compliant, so a
+// scalar it accepted is a valid standalone JSON value. (It is in one respect stricter than
+// encoding/json, having already rejected numbers whose magnitude overflows float64.)
+func (r *tokenReader) rawScalar(start int) ([]byte, error) {
+	return r.data[start:r.pos:r.pos], nil
+}
+
+// rawContainer scans from the already-consumed opening delimiter (open) to the matching close and
+// then validates the captured bytes with encoding/json. The boundary scan only tracks the outer
+// delimiter kind (mirroring the easyjson build's jlexer.Raw); json.Valid is the single source of
+// truth for structural correctness, so both build tags accept and reject the same input.
+func (r *tokenReader) rawContainer(open byte, start int) ([]byte, error) {
+	if err := r.scanToContainerEnd(open); err != nil {
+		return nil, err
+	}
+	raw := r.data[start:r.pos:r.pos]
+	if !json.Valid(raw) {
+		return nil, SyntaxError{Message: errMsgInvalidValue, Offset: start}
+	}
+	return raw, nil
+}
+
+// scanToContainerEnd advances the read position past the end of the array or object value whose
+// opening delimiter (open) has already been consumed. It counts only the outer delimiter kind and
+// skips string literals, locating the value's byte boundary without validating nested structure;
+// the caller validates the captured bytes via json.Valid. This mirrors jlexer.SkipRecursive in
+// the easyjson build so both tags capture the same bytes.
+func (r *tokenReader) scanToContainerEnd(open byte) error {
+	end := byte(']')
+	if open == '{' {
+		end = '}'
+	}
+	level := 1
+	for level > 0 {
+		b, ok := r.readByte()
+		if !ok {
+			return io.EOF
+		}
+		switch b {
+		case '"':
+			if err := r.scanStringEnd(); err != nil {
+				return err
+			}
+		case open:
+			level++
+		case end:
+			level--
+		}
+	}
+	return nil
+}
+
+// scanStringEnd advances the read position past the remainder of a string literal whose opening
+// quote mark has already been consumed, honoring backslash escapes. It does not interpret escape
+// sequences or validate the string's characters.
+func (r *tokenReader) scanStringEnd() error {
+	for {
+		b, ok := r.readByte()
+		if !ok {
+			return SyntaxError{Message: errMsgInvalidString, Offset: r.lastPos}
+		}
+		switch b {
+		case '\\':
+			if _, ok := r.readByte(); !ok {
+				return SyntaxError{Message: errMsgInvalidString, Offset: r.lastPos}
+			}
+		case '"':
+			return nil
+		}
 	}
 }
 

--- a/jreader/token_reader_easyjson.go
+++ b/jreader/token_reader_easyjson.go
@@ -183,6 +183,10 @@ func (tr *tokenReader) any(_ bool) (AnyValue, error) {
 	return value, nil
 }
 
+// Note: there is deliberately no RawValue implementation for this build variant. easyjson
+// support is planned for removal from this library, so Reader.RawValue is provided only by the
+// default tokenizer (it is declared in reader_default.go and does not exist under this tag).
+
 func (tr *tokenReader) lexerError() error {
 	if tr.pLexer == nil {
 		return tr.inlineLexer.Error()


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
chore: Add Reader.RawValue and Reader.Offset for raw value capture
END_COMMIT_OVERRIDE

Returns the raw bytes of the next JSON value as a zero-copy slice of the
reader's input, consuming the value. Scalars are fully validated; array and
object values are scanned with a fast string-aware delimiter-matching pass.

Implemented for both the default tokenizer (position-based span capture) and
the launchdarkly_easyjson build variant (jlexer.Raw).

This enables consumers that need both a parsed representation and the
verbatim JSON of the same value (for example, the FDv2 data sources in
go-server-sdk, which store parsed items and relay raw bytes downstream) to
avoid re-scanning or copying the input.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core tokenizer behavior and JSON acceptance boundaries for containers; mistakes could change what bytes are relayed downstream, though the change is additive and heavily tested against encoding/json.
> 
> **Overview**
> Adds **`Reader.RawValue()`** and **`Reader.Offset()`** on the **default** build (`!launchdarkly_easyjson`) so callers can keep verbatim JSON alongside typed parsing without re-scanning or copying the input buffer.
> 
> **`RawValue`** consumes the next value and returns a **zero-copy** slice (`cap == len`) into the reader’s input. Scalars use the existing RFC 8259 tokenizer; arrays/objects use a **string-aware delimiter scan** followed by **`encoding/json.Valid`** on the captured span. Invalid containers surface a new **`errMsgInvalidValue`** syntax error. The method handles **unread-token** state (e.g. after a `Null()` probe).
> 
> **`Offset`** reports the next byte to consume (or the start of a pushed-back token), documented for the alternative pattern: slice `input[start:Offset]` around an in-place parse, trimming JSON whitespace at the ends.
> 
> The **easyjson** build intentionally omits both APIs (comment only). Coverage includes unit tests, **differential/oracle tests against `encoding/json`**, generative fuzz, and offset-span tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5e12765c7bb547f6d1bf6195d2261c2f8648b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->