### PR TITLE
fix: Improve jwriter throughput with append-based buffer internals

### DIFF
--- a/jwriter/streamable_buffer.go
+++ b/jwriter/streamable_buffer.go
@@ -1,23 +1,34 @@
 package jwriter
 
 import (
-	"bytes"
 	"io"
+	"unicode/utf8"
 )
 
+// streamableBuffer is a byte buffer that can optionally flush its contents to an io.Writer
+// whenever they reach a chunk size. The zero value is a ready-to-use in-memory buffer.
+//
+// Output accumulates in a plain byte slice via append operations, which the compiler can
+// inline at call sites, rather than through bytes.Buffer method calls. For the same reason,
+// tokenWriter appends directly to the buf field in its hottest code paths; any code that
+// does so must call maybeFlush afterward so that streaming mode keeps flushing incrementally.
 type streamableBuffer struct {
-	buf       bytes.Buffer
+	buf       []byte
 	dest      io.Writer
 	destErr   error
 	chunkSize int
 }
 
 func (b *streamableBuffer) Bytes() []byte {
-	return b.buf.Bytes()
+	return b.buf
 }
 
 func (b *streamableBuffer) Grow(n int) {
-	b.buf.Grow(n)
+	if cap(b.buf)-len(b.buf) < n {
+		newBuf := make([]byte, len(b.buf), len(b.buf)+n)
+		copy(newBuf, b.buf)
+		b.buf = newBuf
+	}
 }
 
 func (b *streamableBuffer) SetStreamingWriter(w io.Writer, chunkSize int) {
@@ -27,12 +38,11 @@ func (b *streamableBuffer) SetStreamingWriter(w io.Writer, chunkSize int) {
 
 func (b *streamableBuffer) Flush() error {
 	if b.dest != nil {
-		if b.buf.Len() > 0 {
+		if len(b.buf) > 0 {
 			if b.destErr == nil {
-				data := b.buf.Bytes()
-				_, b.destErr = b.dest.Write(data)
+				_, b.destErr = b.dest.Write(b.buf)
 			}
-			b.buf.Reset()
+			b.buf = b.buf[:0]
 			return b.destErr
 		}
 	}
@@ -40,7 +50,7 @@ func (b *streamableBuffer) Flush() error {
 }
 
 func (b *streamableBuffer) maybeFlush() {
-	if b.dest != nil && b.buf.Len() >= b.chunkSize {
+	if b.dest != nil && len(b.buf) >= b.chunkSize {
 		_ = b.Flush()
 	}
 }
@@ -50,21 +60,21 @@ func (b *streamableBuffer) GetWriterError() error {
 }
 
 func (b *streamableBuffer) Write(data []byte) {
-	_, _ = b.buf.Write(data)
+	b.buf = append(b.buf, data...)
 	b.maybeFlush()
 }
 
 func (b *streamableBuffer) WriteByte(data byte) { //nolint:govet
-	_ = b.buf.WriteByte(data)
+	b.buf = append(b.buf, data)
 	b.maybeFlush()
 }
 
 func (b *streamableBuffer) WriteRune(ch rune) {
-	_, _ = b.buf.WriteRune(ch)
+	b.buf = utf8.AppendRune(b.buf, ch)
 	b.maybeFlush()
 }
 
 func (b *streamableBuffer) WriteString(s string) {
-	_, _ = b.buf.WriteString(s)
+	b.buf = append(b.buf, s...)
 	b.maybeFlush()
 }

--- a/jwriter/streamable_buffer.go
+++ b/jwriter/streamable_buffer.go
@@ -12,6 +12,11 @@ import (
 // inline at call sites, rather than through bytes.Buffer method calls. For the same reason,
 // tokenWriter appends directly to the buf field in its hottest code paths; any code that
 // does so must call maybeFlush afterward so that streaming mode keeps flushing incrementally.
+//
+// Code paths that append many bytes at a time should call reserve first: bare append grows
+// large slices by only ~1.25x, and the doubling policy in reserve keeps the number of
+// reallocations (and the total bytes copied) logarithmic for large outputs, matching the
+// amortization that bytes.Buffer provided.
 type streamableBuffer struct {
 	buf       []byte
 	dest      io.Writer
@@ -23,9 +28,24 @@ func (b *streamableBuffer) Bytes() []byte {
 	return b.buf
 }
 
+// Grow ensures that the buffer has room for at least n more bytes, reallocating it if
+// necessary. It panics if n is negative.
 func (b *streamableBuffer) Grow(n int) {
+	if n < 0 {
+		panic("jwriter: cannot grow buffer by a negative count")
+	}
+	b.reserve(n)
+}
+
+// reserve ensures that the buffer has room for at least n more bytes, at least doubling the
+// capacity when it must reallocate so that repeated bulk appends remain amortized.
+func (b *streamableBuffer) reserve(n int) {
 	if cap(b.buf)-len(b.buf) < n {
-		newBuf := make([]byte, len(b.buf), len(b.buf)+n)
+		newCap := 2 * cap(b.buf)
+		if newCap < len(b.buf)+n {
+			newCap = len(b.buf) + n
+		}
+		newBuf := make([]byte, len(b.buf), newCap)
 		copy(newBuf, b.buf)
 		b.buf = newBuf
 	}
@@ -36,17 +56,24 @@ func (b *streamableBuffer) SetStreamingWriter(w io.Writer, chunkSize int) {
 	b.chunkSize = chunkSize
 }
 
+// Flush writes any buffered output to the destination, if there is one. Once a destination
+// write has failed, the failure is remembered and returned by every subsequent Flush call,
+// even after the buffered data that could not be delivered has been discarded.
 func (b *streamableBuffer) Flush() error {
-	if b.dest != nil {
-		if len(b.buf) > 0 {
-			if b.destErr == nil {
-				_, b.destErr = b.dest.Write(b.buf)
-			}
-			b.buf = b.buf[:0]
-			return b.destErr
-		}
+	if b.dest == nil {
+		return nil
 	}
-	return nil
+	if len(b.buf) > 0 {
+		if b.destErr == nil {
+			n, err := b.dest.Write(b.buf)
+			if err == nil && n < len(b.buf) {
+				err = io.ErrShortWrite
+			}
+			b.destErr = err
+		}
+		b.buf = b.buf[:0]
+	}
+	return b.destErr
 }
 
 func (b *streamableBuffer) maybeFlush() {
@@ -75,6 +102,7 @@ func (b *streamableBuffer) WriteRune(ch rune) {
 }
 
 func (b *streamableBuffer) WriteString(s string) {
+	b.reserve(len(s))
 	b.buf = append(b.buf, s...)
 	b.maybeFlush()
 }

--- a/jwriter/streamable_buffer.go
+++ b/jwriter/streamable_buffer.go
@@ -13,10 +13,17 @@ import (
 // tokenWriter appends directly to the buf field in its hottest code paths; any code that
 // does so must call maybeFlush afterward so that streaming mode keeps flushing incrementally.
 //
-// Code paths that append many bytes at a time should call reserve first: bare append grows
-// large slices by only ~1.25x, and the doubling policy in reserve keeps the number of
-// reallocations (and the total bytes copied) logarithmic for large outputs, matching the
-// amortization that bytes.Buffer provided.
+// Token-level writes — strings, numbers, and the multi-byte Write used for keyword and
+// raw tokens — reserve capacity before appending: bare append grows large slices by only
+// ~1.25x, and the at-least-doubling policy in reserve keeps the number of reallocations
+// (and the total bytes copied) logarithmic for large outputs. WriteByte and WriteRune
+// deliberately do not reserve: a capacity check on every single-byte delimiter write
+// measurably slows encoding, and a growth triggered by one is made rare by the reserves
+// on the token writes around it.
+//
+// The chunk-size check happens after a write, never during one, so a single write larger
+// than the chunk size — a raw JSON value, or a long escape-free string segment — is
+// buffered whole before it is flushed.
 type streamableBuffer struct {
 	buf       []byte
 	dest      io.Writer
@@ -29,7 +36,7 @@ func (b *streamableBuffer) Bytes() []byte {
 }
 
 // Grow ensures that the buffer has room for at least n more bytes, reallocating it if
-// necessary. It panics if n is negative.
+// necessary. It panics if n is negative or if the buffer cannot grow that large.
 func (b *streamableBuffer) Grow(n int) {
 	if n < 0 {
 		panic("jwriter: cannot grow buffer by a negative count")
@@ -37,10 +44,14 @@ func (b *streamableBuffer) Grow(n int) {
 	b.reserve(n)
 }
 
-// reserve ensures that the buffer has room for at least n more bytes, at least doubling the
-// capacity when it must reallocate so that repeated bulk appends remain amortized.
+// reserve ensures that the buffer has room for at least n more bytes (n must not be
+// negative), at least doubling the capacity when it must reallocate so that repeated
+// appends remain amortized.
 func (b *streamableBuffer) reserve(n int) {
 	if cap(b.buf)-len(b.buf) < n {
+		if len(b.buf)+n < 0 {
+			panic("jwriter: buffer too large")
+		}
 		newCap := 2 * cap(b.buf)
 		if newCap < len(b.buf)+n {
 			newCap = len(b.buf) + n
@@ -87,6 +98,7 @@ func (b *streamableBuffer) GetWriterError() error {
 }
 
 func (b *streamableBuffer) Write(data []byte) {
+	b.reserve(len(data))
 	b.buf = append(b.buf, data...)
 	b.maybeFlush()
 }

--- a/jwriter/streamable_buffer_test.go
+++ b/jwriter/streamable_buffer_test.go
@@ -2,6 +2,7 @@ package jwriter
 
 import (
 	"bytes"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -81,5 +82,8 @@ func TestStreamableBufferGrow(t *testing.T) {
 	require.Equal(t, "abc", string(b.Bytes()))
 	b.WriteString("def")
 	require.Equal(t, "abcdef", string(b.Bytes()))
-	require.Panics(t, func() { b.Grow(-1) })
+	require.PanicsWithValue(t, "jwriter: cannot grow buffer by a negative count",
+		func() { b.Grow(-1) })
+	require.PanicsWithValue(t, "jwriter: buffer too large",
+		func() { b.Grow(math.MaxInt) })
 }

--- a/jwriter/streamable_buffer_test.go
+++ b/jwriter/streamable_buffer_test.go
@@ -72,3 +72,14 @@ func writeTestDataToBuffer(b *streamableBuffer) string {
 
 	return expected
 }
+
+func TestStreamableBufferGrow(t *testing.T) {
+	var b streamableBuffer
+	b.WriteString("abc")
+	b.Grow(100)
+	require.GreaterOrEqual(t, cap(b.Bytes())-len(b.Bytes()), 100)
+	require.Equal(t, "abc", string(b.Bytes()))
+	b.WriteString("def")
+	require.Equal(t, "abcdef", string(b.Bytes()))
+	require.Panics(t, func() { b.Grow(-1) })
+}

--- a/jwriter/token_writer_default.go
+++ b/jwriter/token_writer_default.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"math"
 	"strconv"
-	"unicode/utf8"
 )
 
 // errNonFiniteNumber is returned when attempting to write a NaN or infinite floating-point
@@ -22,13 +21,21 @@ var (
 	tokenFalse = []byte("false") //nolint:gochecknoglobals
 )
 
+const hexDigits = "0123456789abcdef"
+
+// initialBufferCapacity is the buffer capacity preallocated by newTokenWriter. Paying for one
+// small allocation up front keeps the growth ladder short for typical outputs; it is the same
+// minimum that bytes.Buffer uses.
+const initialBufferCapacity = 64
+
 type tokenWriter struct {
-	buf       streamableBuffer
-	tempBytes [50]byte
+	buf streamableBuffer
 }
 
 func newTokenWriter() tokenWriter {
-	return tokenWriter{}
+	tw := tokenWriter{}
+	tw.buf.buf = make([]byte, 0, initialBufferCapacity)
+	return tw
 }
 
 func newStreamingTokenWriter(dest io.Writer, bufferSize int) tokenWriter {
@@ -46,8 +53,8 @@ func (tw *tokenWriter) Bytes() []byte {
 	return tw.buf.Bytes()
 }
 
-// Grow expands the internal buffer by the specified number of bytes. It is the same as calling Grow
-// on a bytes.Buffer.
+// Grow ensures that the internal buffer has room for the specified number of additional bytes,
+// reallocating it if necessary.
 func (tw *tokenWriter) Grow(n int) {
 	tw.buf.Grow(n)
 }
@@ -78,13 +85,8 @@ func (tw *tokenWriter) Bool(value bool) error {
 
 // Int writes an integer JSON number.
 func (tw *tokenWriter) Int(value int) error {
-	if value == 0 {
-		tw.buf.WriteByte('0')
-	} else {
-		out := tw.tempBytes[0:0]
-		out = strconv.AppendInt(out, int64(value), 10)
-		tw.buf.Write(out)
-	}
+	tw.buf.buf = strconv.AppendInt(tw.buf.buf, int64(value), 10)
+	tw.buf.maybeFlush()
 	return tw.buf.GetWriterError()
 }
 
@@ -100,9 +102,8 @@ func (tw *tokenWriter) Float64(value float64) error {
 		if float64(i) == value {
 			return tw.Int(i)
 		}
-		out := tw.tempBytes[0:0]
-		out = strconv.AppendFloat(out, value, 'g', -1, 64)
-		tw.buf.Write(out)
+		tw.buf.buf = strconv.AppendFloat(tw.buf.buf, value, 'g', -1, 64)
+		tw.buf.maybeFlush()
 	}
 	return tw.buf.GetWriterError()
 }
@@ -134,62 +135,48 @@ func (tw *tokenWriter) Delimiter(delimiter byte) error {
 }
 
 func (tw *tokenWriter) writeQuotedString(s string) error {
-	// This is basically the same logic used internally by json.Marshal
-	tw.buf.WriteByte('"')
+	// This is basically the same logic used internally by json.Marshal: scan for the next byte
+	// that requires escaping, and copy the whole clean segment before it in one append. Bytes
+	// outside the ASCII range never require escaping, so multi-byte characters are copied
+	// through without being decoded. The whole string is appended before the buffer's chunk-size
+	// check runs, so in streaming mode a long string may overshoot the chunk size; the buffer
+	// permits that, and this keeps the check out of the per-byte loop.
+	dst := tw.buf.buf
+	dst = append(dst, '"')
 	start := 0
-	for i := 0; i < len(s); {
+	for i := 0; i < len(s); i++ {
 		aByte := s[i]
-		if aByte < ' ' || aByte == '"' || aByte == '\\' {
-			if i > start {
-				tw.buf.WriteString(s[start:i])
-			}
-			tw.writeEscapedChar(aByte)
-			i++
-			start = i
-		} else {
-			if aByte < utf8.RuneSelf { // single-byte character
-				i++
-			} else {
-				_, size := utf8.DecodeRuneInString(s[i:])
-				i += size
-			}
+		if aByte >= ' ' && aByte != '"' && aByte != '\\' {
+			continue
 		}
+		dst = append(dst, s[start:i]...)
+		dst = appendEscapedChar(dst, aByte)
+		start = i + 1
 	}
-	if start < len(s) {
-		tw.buf.WriteString(s[start:])
-	}
-	tw.buf.WriteByte('"')
+	dst = append(dst, s[start:]...)
+	dst = append(dst, '"')
+	tw.buf.buf = dst
+	tw.buf.maybeFlush()
 	return tw.buf.GetWriterError()
 }
 
-func (tw *tokenWriter) writeEscapedChar(ch byte) {
-	out := tw.tempBytes[0:2]
-	out[0] = '\\'
+func appendEscapedChar(dst []byte, ch byte) []byte {
 	switch ch {
 	case '\b':
-		out[1] = 'b'
+		return append(dst, '\\', 'b')
 	case '\t':
-		out[1] = 't'
+		return append(dst, '\\', 't')
 	case '\n':
-		out[1] = 'n'
+		return append(dst, '\\', 'n')
 	case '\f':
-		out[1] = 'f'
+		return append(dst, '\\', 'f')
 	case '\r':
-		out[1] = 'r'
+		return append(dst, '\\', 'r')
 	case '"':
-		out[1] = '"'
+		return append(dst, '\\', '"')
 	case '\\':
-		out[1] = '\\'
+		return append(dst, '\\', '\\')
 	default:
-		out[1] = 'u'
-		out = append(out, '0')
-		out = append(out, '0')
-		hexChars := make([]byte, 0, 4)
-		hexChars = strconv.AppendInt(hexChars, int64(ch), 16)
-		if len(hexChars) < 2 {
-			out = append(out, '0')
-		}
-		out = append(out, hexChars...)
+		return append(dst, '\\', 'u', '0', '0', hexDigits[ch>>4], hexDigits[ch&0xf])
 	}
-	tw.buf.Write(out)
 }

--- a/jwriter/token_writer_default.go
+++ b/jwriter/token_writer_default.go
@@ -62,12 +62,6 @@ func (tw *tokenWriter) Bytes() []byte {
 	return tw.buf.Bytes()
 }
 
-// Grow ensures that the internal buffer has room for the specified number of additional bytes,
-// reallocating it if necessary.
-func (tw *tokenWriter) Grow(n int) {
-	tw.buf.Grow(n)
-}
-
 // Flush writes any remaining in-memory output to the underlying Writer, if this is a streaming buffer
 // created with newStreamingTokenWriter. It has no effect otherwise.
 func (tw *tokenWriter) Flush() error {
@@ -126,7 +120,6 @@ func (tw *tokenWriter) String(value string) error {
 
 // Raw writes a preformatted chunk of JSON data.
 func (tw *tokenWriter) Raw(value json.RawMessage) error {
-	tw.buf.reserve(len(value))
 	tw.buf.Write(value)
 	return tw.buf.GetWriterError()
 }
@@ -152,8 +145,9 @@ func (tw *tokenWriter) writeQuotedString(s string) error {
 	// outside the ASCII range are copied through verbatim without being decoded, since this
 	// writer only ever escapes control characters, quotes, and backslashes.
 	//
-	// In-memory mode reserves the full encoded length up front (plus room for expansion when
-	// escapes are found). Streaming mode must not do that: it reserves nothing and instead
+	// In-memory mode reserves len(s)+2 up front — the exact encoded length when nothing needs
+	// escaping; escape expansion beyond that grows through append. Streaming mode must not
+	// reserve by input length: it reserves nothing and instead
 	// flushes at chunk boundaries as it scans, so that the buffer stays near the chunk size
 	// no matter how long or escape-heavy the input string is. A clean segment is still
 	// appended in one piece, so a segment longer than the chunk size overshoots it by that

--- a/jwriter/token_writer_default.go
+++ b/jwriter/token_writer_default.go
@@ -24,17 +24,26 @@ var (
 const hexDigits = "0123456789abcdef"
 
 // initialBufferCapacity is the buffer capacity preallocated by newTokenWriter. Paying for one
-// small allocation up front keeps the growth ladder short for typical outputs; it is the same
-// minimum that bytes.Buffer uses.
+// small allocation up front keeps the append growth ladder short for typical outputs; it is
+// the same minimum that bytes.Buffer uses.
 const initialBufferCapacity = 64
+
+// maxNumberLength is the longest text that Int or Float64 can produce for one value: a
+// float64 in Go's shortest 'g' representation needs at most 24 characters (for example
+// "-1.7976931348623157e+308"), and an int64 needs at most 20.
+const maxNumberLength = 24
 
 type tokenWriter struct {
 	buf streamableBuffer
 }
 
 func newTokenWriter() tokenWriter {
+	return newTokenWriterWithCapacity(initialBufferCapacity)
+}
+
+func newTokenWriterWithCapacity(capacity int) tokenWriter {
 	tw := tokenWriter{}
-	tw.buf.buf = make([]byte, 0, initialBufferCapacity)
+	tw.buf.buf = make([]byte, 0, capacity)
 	return tw
 }
 
@@ -85,6 +94,7 @@ func (tw *tokenWriter) Bool(value bool) error {
 
 // Int writes an integer JSON number.
 func (tw *tokenWriter) Int(value int) error {
+	tw.buf.reserve(maxNumberLength)
 	tw.buf.buf = strconv.AppendInt(tw.buf.buf, int64(value), 10)
 	tw.buf.maybeFlush()
 	return tw.buf.GetWriterError()
@@ -102,6 +112,7 @@ func (tw *tokenWriter) Float64(value float64) error {
 		if float64(i) == value {
 			return tw.Int(i)
 		}
+		tw.buf.reserve(maxNumberLength)
 		tw.buf.buf = strconv.AppendFloat(tw.buf.buf, value, 'g', -1, 64)
 		tw.buf.maybeFlush()
 	}
@@ -115,6 +126,7 @@ func (tw *tokenWriter) String(value string) error {
 
 // Raw writes a preformatted chunk of JSON data.
 func (tw *tokenWriter) Raw(value json.RawMessage) error {
+	tw.buf.reserve(len(value))
 	tw.buf.Write(value)
 	return tw.buf.GetWriterError()
 }
@@ -137,10 +149,20 @@ func (tw *tokenWriter) Delimiter(delimiter byte) error {
 func (tw *tokenWriter) writeQuotedString(s string) error {
 	// This is basically the same logic used internally by json.Marshal: scan for the next byte
 	// that requires escaping, and copy the whole clean segment before it in one append. Bytes
-	// outside the ASCII range never require escaping, so multi-byte characters are copied
-	// through without being decoded. The whole string is appended before the buffer's chunk-size
-	// check runs, so in streaming mode a long string may overshoot the chunk size; the buffer
-	// permits that, and this keeps the check out of the per-byte loop.
+	// outside the ASCII range are copied through verbatim without being decoded, since this
+	// writer only ever escapes control characters, quotes, and backslashes.
+	//
+	// In-memory mode reserves the full encoded length up front (plus room for expansion when
+	// escapes are found). Streaming mode must not do that: it reserves nothing and instead
+	// flushes at chunk boundaries as it scans, so that the buffer stays near the chunk size
+	// no matter how long or escape-heavy the input string is. A clean segment is still
+	// appended in one piece, so a segment longer than the chunk size overshoots it by that
+	// segment's length, which the buffer permits.
+	if tw.buf.dest == nil {
+		tw.buf.reserve(len(s) + 2)
+	}
+	// dst is a local copy of the buffer's slice header; it must be stored back before any
+	// buffer method runs (and reloaded after), or the flushed bytes would reappear.
 	dst := tw.buf.buf
 	dst = append(dst, '"')
 	start := 0
@@ -152,6 +174,11 @@ func (tw *tokenWriter) writeQuotedString(s string) error {
 		dst = append(dst, s[start:i]...)
 		dst = appendEscapedChar(dst, aByte)
 		start = i + 1
+		if tw.buf.dest != nil && len(dst) >= tw.buf.chunkSize {
+			tw.buf.buf = dst
+			tw.buf.maybeFlush()
+			dst = tw.buf.buf
+		}
 	}
 	dst = append(dst, s[start:]...)
 	dst = append(dst, '"')

--- a/jwriter/writer.go
+++ b/jwriter/writer.go
@@ -54,9 +54,15 @@ func (w *Writer) AddError(err error) {
 }
 
 // Flush writes any remaining in-memory output to the underlying io.Writer, if this is a streaming
-// writer created with NewStreamingWriter. It has no effect otherwise.
+// writer created with NewStreamingWriter. It has no effect otherwise. If the underlying io.Writer
+// has failed, either now or during an earlier automatic flush, Flush returns that error and the
+// Writer also records it, so Error() will report it as well.
 func (w *Writer) Flush() error {
-	return w.tw.Flush()
+	if err := w.tw.Flush(); err != nil {
+		w.AddError(err)
+		return err
+	}
+	return nil
 }
 
 // Null writes a JSON null value to the output.

--- a/jwriter/writer.go
+++ b/jwriter/writer.go
@@ -18,6 +18,10 @@ import (
 // when using NewStreamingWriter), or if an error is explicitly raised with AddError, the Writer
 // permanently enters a failed state and remembers that error; all subsequent method calls for
 // producing output will be ignored.
+//
+// Like a bytes.Buffer, a Writer must not be copied: copies share the same output buffer and
+// will corrupt each other's output. Use a pointer, or write through the states returned by
+// Array and Object.
 type Writer struct {
 	tw    tokenWriter
 	err   error

--- a/jwriter/writer_init_default.go
+++ b/jwriter/writer_init_default.go
@@ -7,6 +7,9 @@ import "io"
 // This function returns the struct by value (Writer, not *Writer). This avoids the overhead of a
 // heap allocation since, in typical usage, the Writer will not escape the scope in which it was
 // declared and can remain on the stack.
+//
+// Like a bytes.Buffer, the returned Writer must not be copied: it contains a preallocated
+// output buffer, so copies of it would write into the same memory.
 func NewWriter() Writer {
 	return Writer{tw: newTokenWriter()}
 }

--- a/jwriter/writer_init_default.go
+++ b/jwriter/writer_init_default.go
@@ -17,6 +17,7 @@ func NewWriter() Writer {
 // NewStreamingWriter creates a Writer that will buffer a limited amount of its output in memory
 // and dump the output to the specified io.Writer whenever the buffer is full. You should also
 // call Flush at the end of your output to ensure that any remaining buffered output is flushed.
+// It panics if bufferSize is negative.
 //
 // If the Writer returns an error at any point, it enters a failed state and will not try to
 // write any more data to the target.
@@ -24,6 +25,9 @@ func NewWriter() Writer {
 // This function returns the struct by value (Writer, not *Writer). This avoids the overhead of a
 // heap allocation since, in typical usage, the Writer will not escape the scope in which it was
 // declared and can remain on the stack.
+//
+// Like a bytes.Buffer, the returned Writer must not be copied: it contains a preallocated
+// output buffer, so copies of it would write into the same memory.
 func NewStreamingWriter(target io.Writer, bufferSize int) Writer {
 	return Writer{tw: newStreamingTokenWriter(target, bufferSize)}
 }

--- a/jwriter/writer_marshal.go
+++ b/jwriter/writer_marshal.go
@@ -1,10 +1,13 @@
 package jwriter
 
+// marshalInitialCapacity is the output buffer capacity that MarshalJSONWithWriter starts
+// with, sized so that most documents marshal without reallocating.
+const marshalInitialCapacity = 1000
+
 // MarshalJSONWithWriter is a convenience method for implementing json.Marshaler to marshal to a
 // byte slice with the default TokenWriter implementation.
 func MarshalJSONWithWriter(writable Writable) ([]byte, error) {
-	w := NewWriter()
-	w.tw.Grow(1000)
+	w := Writer{tw: newTokenWriterWithCapacity(marshalInitialCapacity)}
 	writable.WriteToJSONWriter(&w)
 	if err := w.Error(); err != nil {
 		return nil, err

--- a/jwriter/writer_marshal_test.go
+++ b/jwriter/writer_marshal_test.go
@@ -6,10 +6,37 @@ import (
 	"github.com/launchdarkly/go-jsonstream/v4/internal/commontest"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMarshalJSONWithWriter(t *testing.T) {
 	data, err := MarshalJSONWithWriter(ExampleStructWrapper(commontest.ExampleStructValue))
 	assert.NoError(t, err)
 	assert.Equal(t, commontest.ExampleStructData, data)
+}
+
+// marshalAllocationTestWritable emits a document of several hundred bytes: larger than the
+// 64-byte buffer a plain NewWriter starts with, but within MarshalJSONWithWriter's initial
+// capacity, so the allocation assertion below fails if that capacity is ever lost.
+type marshalAllocationTestWritable struct{}
+
+func (marshalAllocationTestWritable) WriteToJSONWriter(w *Writer) {
+	arr := w.Array()
+	for i := 0; i < 20; i++ {
+		arr.String("string value for the allocation test")
+	}
+	arr.End()
+}
+
+func TestMarshalJSONWithWriterAllocations(t *testing.T) {
+	var writable Writable = marshalAllocationTestWritable{}
+	allocs := testing.AllocsPerRun(500, func() {
+		data, err := MarshalJSONWithWriter(writable)
+		if err != nil || len(data) == 0 {
+			t.Fail()
+		}
+	})
+	// One allocation for the Writer (it escapes through the Writable interface) and one
+	// for the output buffer, allocated once at full size.
+	require.LessOrEqual(t, allocs, 2.0)
 }

--- a/jwriter/writer_streaming_default_test.go
+++ b/jwriter/writer_streaming_default_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -45,6 +46,8 @@ func TestStreamingWriterWritesToTargetInChunks(t *testing.T) {
 	require.Equal(t, expected, buf.String())
 }
 
+var errFailingDestination = errors.New("destination failed")
+
 type failingDestination struct {
 	failAfter int // number of successful writes before failures begin
 	writes    int
@@ -53,9 +56,21 @@ type failingDestination struct {
 func (f *failingDestination) Write(p []byte) (int, error) {
 	f.writes++
 	if f.writes > f.failAfter {
-		return 0, errors.New("destination failed")
+		return 0, errFailingDestination
 	}
 	return len(p), nil
+}
+
+// truncatingDestination reports success but consumes one byte less than it was given,
+// violating the io.Writer contract.
+type truncatingDestination struct{}
+
+func (truncatingDestination) Write(p []byte) (int, error) {
+	n := len(p) - 1
+	if n < 0 {
+		n = 0
+	}
+	return n, nil
 }
 
 func writeStreamingTestDocument(w *Writer) {
@@ -88,8 +103,12 @@ func TestStreamingWriterSurfacesDestinationError(t *testing.T) {
 			f := &failingDestination{failAfter: c.failAfter}
 			w := NewStreamingWriter(f, c.chunkSize)
 			writeStreamingTestDocument(&w)
-			require.Error(t, w.Flush())
-			require.Error(t, w.Error())
+			require.True(t, errors.Is(w.Flush(), errFailingDestination))
+			require.True(t, errors.Is(w.Error(), errFailingDestination))
+			// The destination must see exactly one failing write and nothing afterward, and
+			// the undeliverable data must have been discarded rather than retained.
+			require.Equal(t, c.failAfter+1, f.writes)
+			require.Empty(t, w.tw.buf.Bytes())
 		})
 	}
 }
@@ -146,4 +165,11 @@ func TestStreamingWriterBoundsBufferForEscapeHeavyStrings(t *testing.T) {
 	require.NoError(t, w.Flush())
 	require.Equal(t, `"`+strings.Repeat(`\n`, inputLen)+`"`, target.String())
 	require.LessOrEqual(t, cap(w.tw.buf.Bytes()), 4*chunkSize)
+}
+
+func TestStreamingWriterSurfacesShortWrite(t *testing.T) {
+	w := NewStreamingWriter(truncatingDestination{}, 10)
+	writeStreamingTestDocument(&w)
+	require.True(t, errors.Is(w.Flush(), io.ErrShortWrite))
+	require.True(t, errors.Is(w.Error(), io.ErrShortWrite))
 }

--- a/jwriter/writer_streaming_default_test.go
+++ b/jwriter/writer_streaming_default_test.go
@@ -2,6 +2,10 @@ package jwriter
 
 import (
 	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -39,4 +43,107 @@ func TestStreamingWriterWritesToTargetInChunks(t *testing.T) {
 	require.NoError(t, w.Flush())
 	expected += `]`
 	require.Equal(t, expected, buf.String())
+}
+
+type failingDestination struct {
+	failAfter int // number of successful writes before failures begin
+	writes    int
+}
+
+func (f *failingDestination) Write(p []byte) (int, error) {
+	f.writes++
+	if f.writes > f.failAfter {
+		return 0, errors.New("destination failed")
+	}
+	return len(p), nil
+}
+
+func writeStreamingTestDocument(w *Writer) {
+	arr := w.Array()
+	arr.String("hello world")
+	arr.Int(1)
+	arr.String("value\twith\n\"escaped chars\"")
+	arr.Float64(2.5)
+	arr.Null()
+	arr.Bool(true)
+	obj := arr.Object()
+	obj.Name("prop").Int(-1234567890)
+	obj.End()
+	arr.Raw(json.RawMessage(`{"raw":[1,2,3]}`))
+	arr.End()
+}
+
+func TestStreamingWriterSurfacesDestinationError(t *testing.T) {
+	// Whenever the destination has failed, both Error() and the final Flush() must report it,
+	// including when a failed mid-stream flush left the buffer empty.
+	cases := []struct{ chunkSize, failAfter int }{
+		{1, 0}, {1, 1}, {1, 2}, {1, 5},
+		{2, 0}, {2, 1},
+		{10, 0}, {10, 1},
+		{50, 0},
+		{1000, 0}, // nothing flushes until the final Flush
+	}
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("chunkSize=%d failAfter=%d", c.chunkSize, c.failAfter), func(t *testing.T) {
+			f := &failingDestination{failAfter: c.failAfter}
+			w := NewStreamingWriter(f, c.chunkSize)
+			writeStreamingTestDocument(&w)
+			require.Error(t, w.Flush())
+			require.Error(t, w.Error())
+		})
+	}
+}
+
+func TestStreamingWriterOutputMatchesInMemoryWriter(t *testing.T) {
+	expectedWriter := NewWriter()
+	writeStreamingTestDocument(&expectedWriter)
+	require.NoError(t, expectedWriter.Error())
+	expected := string(expectedWriter.Bytes())
+
+	for _, chunkSize := range []int{0, 1, 2, 3, 5, 8, 13, 64, 100, 1000} {
+		t.Run(fmt.Sprintf("chunkSize=%d", chunkSize), func(t *testing.T) {
+			var target bytes.Buffer
+			w := NewStreamingWriter(&target, chunkSize)
+			writeStreamingTestDocument(&w)
+			require.NoError(t, w.Flush())
+			require.Equal(t, expected, target.String())
+		})
+	}
+}
+
+func TestStreamingWriterFlushesAfterEachToken(t *testing.T) {
+	// With a chunk size of 1, every completed token must reach the destination immediately;
+	// this pins the invariant that each token-writing code path checks for a flush.
+	var target bytes.Buffer
+	w := NewStreamingWriter(&target, 1)
+
+	arr := w.Array()
+	arr.Int(12345)
+	require.Equal(t, `[12345`, target.String())
+	arr.Float64(2.5)
+	require.Equal(t, `[12345,2.5`, target.String())
+	arr.String("ab\tc")
+	require.Equal(t, `[12345,2.5,"ab\tc"`, target.String())
+	arr.Bool(true)
+	require.Equal(t, `[12345,2.5,"ab\tc",true`, target.String())
+	arr.Raw(json.RawMessage(`{}`))
+	require.Equal(t, `[12345,2.5,"ab\tc",true,{}`, target.String())
+	arr.End()
+	require.Equal(t, `[12345,2.5,"ab\tc",true,{}]`, target.String())
+
+	require.NoError(t, w.Flush())
+	require.Equal(t, `[12345,2.5,"ab\tc",true,{}]`, target.String())
+}
+
+func TestStreamingWriterBoundsBufferForEscapeHeavyStrings(t *testing.T) {
+	// A string full of escaped characters must not make the internal buffer grow in
+	// proportion to the string: the writer flushes at chunk boundaries while scanning.
+	const chunkSize = 1024
+	const inputLen = 200000
+	var target bytes.Buffer
+	w := NewStreamingWriter(&target, chunkSize)
+	w.String(strings.Repeat("\n", inputLen))
+	require.NoError(t, w.Flush())
+	require.Equal(t, `"`+strings.Repeat(`\n`, inputLen)+`"`, target.String())
+	require.LessOrEqual(t, cap(w.tw.buf.Bytes()), 4*chunkSize)
 }

--- a/jwriter/writer_streaming_default_test.go
+++ b/jwriter/writer_streaming_default_test.go
@@ -20,7 +20,7 @@ func TestStreamingWriterWritesToTargetInChunks(t *testing.T) {
 	require.Equal(t, expected, buf.String())
 
 	arr.String("abc")
-	expected += `[true,"abc`
+	expected += `[true,"abc"`
 	require.Equal(t, expected, buf.String())
 
 	arr.Int(33)
@@ -30,13 +30,13 @@ func TestStreamingWriterWritesToTargetInChunks(t *testing.T) {
 	require.Equal(t, expected, buf.String())
 
 	arr.Float64(2.5)
-	expected += `",33,null,`
+	expected += `,33,null,2.5`
 	require.Equal(t, expected, buf.String())
 
 	arr.End()
 	require.Equal(t, expected, buf.String())
 
 	require.NoError(t, w.Flush())
-	expected += `2.5]`
+	expected += `]`
 	require.Equal(t, expected, buf.String())
 }

--- a/jwriter/writer_test.go
+++ b/jwriter/writer_test.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/launchdarkly/go-jsonstream/v4/internal/commontest"
 )
 
@@ -113,5 +115,39 @@ func (f writerValueTestFactory) Value(value commontest.AnyValue, variant commont
 		}
 
 		return w.Error()
+	}
+}
+
+func TestWriterReallocationsAreAmortized(t *testing.T) {
+	// Growing the output buffer must at least double its capacity when tokens are
+	// written, so the number of reallocations stays logarithmic in the output size.
+	// 5000 tokens of each kind produce far under 64 KiB of output, so a doubling ladder
+	// starting at 64 bytes can take at most ~11 steps; the bound below fails if a token
+	// path falls back to append's ~1.25x growth. (The bound has slack because delimiter
+	// writes do not reserve; see the streamableBuffer comment.)
+	const maxSteps = 14
+	writeToken := map[string]func(arr *ArrayState, i int){
+		"string": func(arr *ArrayState, i int) { arr.String("value\twith\n\"escaped chars\"") },
+		"int":    func(arr *ArrayState, i int) { arr.Int(123456789 + i) },
+		"bool":   func(arr *ArrayState, i int) { arr.Bool(i%2 == 0) },
+		"raw":    func(arr *ArrayState, i int) { arr.Raw(json.RawMessage(`{"k":[1,2,3]}`)) },
+	}
+	for kind, write := range writeToken {
+		t.Run(kind, func(t *testing.T) {
+			w := NewWriter()
+			arr := w.Array()
+			steps := 0
+			lastCap := -1
+			for i := 0; i < 5000; i++ {
+				write(&arr, i)
+				if c := cap(w.tw.buf.Bytes()); c != lastCap {
+					steps++
+					lastCap = c
+				}
+			}
+			arr.End()
+			require.NoError(t, w.Error())
+			require.LessOrEqual(t, steps, maxSteps)
+		})
 	}
 }


### PR DESCRIPTION
Resolves #28.

**SDK-2878**

The `jwriter` comparative benchmarks show the default implementation losing to `encoding/json` for arrays of primitives on modern Go — `ArrayOfBools` ~1.4x slower and `ArrayOfStrings` ~1.7x slower on Go 1.24 — contradicting the README's performance claim. Nothing regressed in this library: `encoding/json` adopted cached-encoder, append-based encoding across Go 1.19-1.24, while `jwriter` routes every output fragment through `bytes.Buffer` method calls with a chunk-size check on every write. This PR adopts the same append-based technique internally:

- `streamableBuffer` holds a plain `[]byte`; writes are inlinable appends instead of `bytes.Buffer` method calls. Reallocation at least doubles the capacity (`reserve`), keeping growth amortized like `bytes.Buffer`; bulk writers reserve space before appending.
- String escaping is a single-pass scan that appends whole clean segments directly into the buffer. Bytes outside the ASCII range pass through without rune decoding, and `\u00XX` escapes are built from a hex-digit table. In-memory writers reserve the encoded length up front; streaming writers instead flush at chunk boundaries mid-scan, so the buffer stays near the chunk size even for long escape-heavy strings (previously such strings were buffered fragment by fragment; an escape-free string is still buffered whole, as before).
- `Int`/`Float64` format straight into the buffer with `strconv.AppendInt`/`AppendFloat`, dropping the `tempBytes` staging array.
- The streaming chunk-size check runs once per token instead of once per write.
- `MarshalJSONWithWriter` allocates its buffer at full initial size instead of growing a 64-byte one.

The encoded output is byte-for-byte unchanged. Error handling is strictly better: `Flush` now reports a destination write failure even when a failed mid-stream flush already emptied the buffer (previously such failures could be visible only via `Error()`, or with some chunk sizes lost by `Flush` entirely), records the failure on the `Writer`, and detects short writes.

## Benchmarks

go1.24.3, linux/amd64, i9-10885H. Three interleaved before/after rounds (`-count 2` each) so CPU frequency drift averages out; the `encoding/json` comparatives act as a control and are statistically flat between the two runs. The 10k/100k-element cases were run with the same harness to check behavior at payload sizes shaped like whole-environment marshals (ld-relay PUT events).

```
                                   │    before     │              after                  │
                                   │    sec/op     │    sec/op     vs base               │
WriteBoolean-16                       69.61n ± 21%   61.27n ± 32%        ~ (p=0.065 n=6)
WriteString-16                        83.60n ±  5%   63.50n ± 16%  -24.04% (p=0.002 n=6)
WriteArrayOfBools-16                  2.413µ ±  5%   1.943µ ± 18%  -19.52% (p=0.002 n=6)
WriteArrayOfStrings-16               10.040µ ±  8%   5.936µ ± 19%  -40.87% (p=0.002 n=6)
WriteObject-16                        273.3n ± 13%   182.9n ± 18%  -33.06% (p=0.002 n=6)
StreamingWriterArrayOfStrings-16     11.418µ ± 10%   8.192µ ± 14%  -28.26% (p=0.002 n=6)
ArrayOfStrings, 10k elements         1437.6µ ±  9%   770.1µ ±  8%  -46.43% (p=0.002 n=6)
ArrayOfStrings, 100k elements        14.325m ±  8%   9.588m ±  7%  -33.07% (p=0.002 n=6)
```

Against `encoding/json` in the same run: `WriteArrayOfStrings` is now faster than the stdlib comparative (was 1.7x slower), `WriteArrayOfBools` is at parity (was 1.4x slower), and `WriteObject` remains ~2x faster.

Allocations: `B/op` is equal or lower than base at small and medium sizes (`WriteArrayOfStrings` -12.6%, 10k elements -11.5%); `allocs/op` matches base everywhere except +1 in the streaming benchmark and +1-2 at 10k/100k elements. At 100k elements `B/op` is higher than base (14.0 MiB vs 8.0 MiB) because that payload happens to fill base's final power-of-two buffer to ~100% while the doubling ladder here takes one more step; sizes away from that boundary are at or below base.

## Behavior notes

- In streaming mode, chunk boundaries now fall between tokens (or at escape boundaries inside long strings) rather than at arbitrary fragment positions. Total output is byte-identical; a clean (escape-free) string segment may overshoot the configured chunk size by its own length, which the buffer always permitted. `TestStreamingWriterWritesToTargetInChunks` asserts exact flush positions, so its expected boundaries are updated.
- `NewStreamingWriter` with a negative `bufferSize` panics, as it did when `bytes.Buffer.Grow` backed it.
- `NewWriter().Bytes()` on an unused writer now returns an empty non-nil slice rather than nil (the output buffer is preallocated). For the same reason, the `Writer` value returned by `NewWriter` must not be copied; this matches `bytes.Buffer` semantics and is now documented.

## Testing

- Full test suite passes, including with `-race`; `golangci-lint` clean.
- New tests: streamed output equals in-memory output across chunk sizes 0-1000; destination-failure matrix asserting both `Error()` and `Flush()` surface the error regardless of where the failure lands; per-token flush behavior at chunk size 1; a streaming memory bound for escape-heavy strings; `Grow` semantics (content preserved, capacity guaranteed, negative panics). The failure-matrix, per-token, and `Grow` tests were mutation-checked (deleting the flush check from `Int`, no-op'ing `reserve`, and reverting the `Flush` error fix each make the suite fail).

## Round-2 review changes

- Token-level writes (keywords/raw values via the buffer's `Write`) now reserve capacity like strings and numbers already did, so allocation growth stays amortized even for documents dominated by booleans, nulls, or raw values. The single-byte delimiter writes deliberately do not reserve — benchmarks showed a capacity check on every delimiter costs ~8% geomean across the suite, while reserving only on token writes is statistically flat (p >= 0.29) and restores near-base reallocation ladders for every token kind.
- `Grow`/reserve panic (`jwriter: buffer too large`) when the required capacity overflows, instead of silently allocating less than requested; previously `NewStreamingWriter(dest, math.MaxInt)` succeeded where base panicked.
- The no-copy warning is mirrored on the `Writer` type and `NewStreamingWriter` (which also documents its panic on negative sizes); removed the internal dead `Grow` method.
- New pinning tests, each mutation-verified: reallocation-ladder bound per token kind, exact-allocation pin on `MarshalJSONWithWriter`, short-write detection (`io.ErrShortWrite`), no-writes-after-failure and no-retained-data assertions on the failing-destination matrix, and panic assertions on `Grow`.
