### PR TITLE
fix: Use a byte-class table for the string escape scan in jwriter

### DIFF
--- a/jwriter/token_writer_default.go
+++ b/jwriter/token_writer_default.go
@@ -17,6 +17,22 @@ var (
 
 const hexDigits = "0123456789abcdef"
 
+// plainStringChars marks the bytes that writeQuotedString copies into a JSON string
+// verbatim. Unlike the reader's equivalent table, bytes outside the ASCII range are
+// plain here: this writer never escapes them, so multi-byte characters pass through
+// without inspection. A single table lookup per byte is measurably faster than the
+// equivalent range and equality comparisons in this loop.
+var plainStringChars = makePlainStringChars() //nolint:gochecknoglobals
+
+func makePlainStringChars() (t [256]bool) {
+	for c := 0x20; c < 256; c++ {
+		if c != '"' && c != '\\' {
+			t[c] = true
+		}
+	}
+	return
+}
+
 // initialBufferCapacity is the buffer capacity preallocated by newTokenWriter. Paying for one
 // small allocation up front keeps the append growth ladder short for typical outputs; it is
 // the same minimum that bytes.Buffer uses.
@@ -153,7 +169,7 @@ func (tw *tokenWriter) writeQuotedString(s string) error {
 	start := 0
 	for i := 0; i < len(s); i++ {
 		aByte := s[i]
-		if aByte >= ' ' && aByte != '"' && aByte != '\\' {
+		if plainStringChars[aByte] {
 			continue
 		}
 		dst = append(dst, s[start:i]...)


### PR DESCRIPTION
**SDK-2888**

`writeQuotedString` scans for the next byte that needs escaping with a range check and two equality comparisons per byte. The Go compiler emits that as multiple compare-and-branch pairs per byte, which caps the throughput of the one-byte-per-iteration scan loop; a 256-entry byte-class table is a single always-L1-resident load plus one branch, and is the technique the reader-side tokenizer rewrite uses. This converts the writer's scan to the same idiom. Output is byte-identical.

The table is deliberately not shared with jreader's (in the reader-side rewrite, #52): the predicates differ at both ends. The reader's decode path treats control characters as plain (the lenient read side passes them through verbatim) while this writer must escape them, and it stops at bytes >= 0x80 (its escape-decoding path re-encodes runes) while this writer copies multi-byte characters through verbatim. A shared-table variant using per-package bit flags measured performance-neutral (-0.04%), so each package keeps its own four-line generated table rather than gaining an internal cross-package dependency. Each table's comment notes the contrast.

## Benchmarks

go1.24.3, linux/amd64, interleaved A/B (3 rounds x count 2, benchstat n=6):

```
                        │ comparisons │            table            │
WriteString-16            45.99n ± 3%   46.53n ± 5%  ~ (p=0.937 n=6)
WriteArrayOfStrings-16    4.309µ ± 2%   4.006µ ± 2%  -7.02% (p=0.002 n=6)
WriteObject-16            132.0n ± 3%   124.6n ± 2%  -5.61% (p=0.002 n=6)
geomean                   296.8n        285.3n       -3.88%
```

The single-short-string case is flat (fixed per-call overhead dominates); the win appears wherever string scanning is a meaningful share of the work. For context, the same table-vs-comparisons choice measures much larger on the reader side (+7% to +40% for the comparison chain), where the scan loop is a bigger fraction of total time.

## Testing

Full suite passes including with `-race`; `golangci-lint` clean; `BenchmarkWriteObjectToNoOpWriterNoAllocs` remains 0 allocs/op. The cross-permutation writer suite exercises the new scan against the same expected encodings, including every escape class and multi-byte content.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **`writeQuotedString`** now decides whether a byte can be copied verbatim using a **256-entry `plainStringChars` table** instead of a per-byte range check plus comparisons for `"` and `\`.
> 
> The table marks bytes from `0x20` through `0xFF` as plain except quote and backslash, so **UTF-8 multibyte sequences pass through unchanged** (unlike the reader’s table, which is documented as intentionally separate). **Encoded JSON output is unchanged**; benchmarks show modest gains when string scanning dominates (e.g. arrays of strings, objects).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e8f17ee04c83acbba0b23124c7ea6c425e29442. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
