### PR TITLE
fix: Use a byte-class table for the string escape scan in jwriter

### DIFF
--- a/jwriter/token_writer_default.go
+++ b/jwriter/token_writer_default.go
@@ -23,6 +23,22 @@ var (
 
 const hexDigits = "0123456789abcdef"
 
+// plainStringChars marks the bytes that writeQuotedString copies into a JSON string
+// verbatim. Unlike the reader's equivalent table, bytes outside the ASCII range are
+// plain here: this writer never escapes them, so multi-byte characters pass through
+// without inspection. A single table lookup per byte is measurably faster than the
+// equivalent range and equality comparisons in this loop.
+var plainStringChars = makePlainStringChars() //nolint:gochecknoglobals
+
+func makePlainStringChars() (t [256]bool) {
+	for c := 0x20; c < 256; c++ {
+		if c != '"' && c != '\\' {
+			t[c] = true
+		}
+	}
+	return
+}
+
 // initialBufferCapacity is the buffer capacity preallocated by newTokenWriter. Paying for one
 // small allocation up front keeps the append growth ladder short for typical outputs; it is
 // the same minimum that bytes.Buffer uses.
@@ -159,7 +175,7 @@ func (tw *tokenWriter) writeQuotedString(s string) error {
 	start := 0
 	for i := 0; i < len(s); i++ {
 		aByte := s[i]
-		if aByte >= ' ' && aByte != '"' && aByte != '\\' {
+		if plainStringChars[aByte] {
 			continue
 		}
 		dst = append(dst, s[start:i]...)


### PR DESCRIPTION
**SDK-2888** — backport of #53 to v3, verbatim. Builds on the append-based writer branch (its base), since it converts the scan loop that change introduced.

`writeQuotedString` scans for the next byte needing an escape with a 256-entry byte-class table instead of a range check and two equality comparisons per byte. A table lookup is a single always-L1-resident load plus one branch, which raises the throughput of the one-byte-per-iteration scan loop. Output is byte-identical.

The table is deliberately not shared with jreader's: the predicates differ (this writer copies multi-byte characters through verbatim and must stop below 0x20 to escape control characters).

## Validation

Full suite green under both build tags; lint clean. On v3 vs the append-based branch (interleaved, n=4): `WriteArrayOfStrings` **-4.5%**, `StreamingWriterArrayOfStrings` **-8.0%**, `WriteObjectToNoOpWriterNoAllocs` **-16.4%** (all p=0.029); real-payload whole-environment marshal a further **-3.6%** geomean. Matches the v4 measurement (-3.9% geomean).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Speeds up JSON string encoding by replacing the per-byte range and equality checks in `writeQuotedString` with a 256-entry `plainStringChars` lookup table.
> 
> The scan still escapes only control characters, quotes, and backslashes; multi-byte characters continue to pass through verbatim. Output is byte-identical, with measurable gains on string-heavy marshal paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbd1d48012aa1eac9b034ac01eedf448cb7eca3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->