### PR TITLE
chore: harden the skip-value allocation test against unrelated allocations

### DIFF
--- a/jreader/reader_test.go
+++ b/jreader/reader_test.go
@@ -420,7 +420,13 @@ func TestReaderSkipValueAllocations(t *testing.T) {
 
 	data := []byte(`{"a":1, "b":{"b1":"two", "b2":"three"}, "c":4}`)
 
-	allocs := testing.AllocsPerRun(1, func() {
+	// AllocsPerRun reads an allocation counter that applies to the whole process. An
+	// unrelated allocation on another goroutine, for example a timer or a finalizer, can
+	// increase the result of a single run. The average of 100 runs removes these errors,
+	// because AllocsPerRun divides the total allocation count by the run count and
+	// truncates the result. An allocation in the code under test occurs in each run, so
+	// the result stays 1 or more.
+	allocs := testing.AllocsPerRun(100, func() {
 		r := NewReader(data)
 		obj := r.Object()
 		require.NoError(t, r.Error())


### PR DESCRIPTION
`TestReaderSkipValueAllocations` failed once on the Windows / Go 1.25 / `-race` matrix cell (expected 0 allocations, measured 1) and passed on re-run. The test is sound about the reader — the fragility is in the measurement: `testing.AllocsPerRun` samples the **process-global** malloc counter, and with `runs=1` the assertion is effectively "nothing anywhere in the process allocates during this window." `GOMAXPROCS(1)` serializes goroutines but does not stop them, so one timer fire, finalizer, or stray wakeup during the window reads as a failure — and the `-race` Windows cell has the longest window in the matrix.

The fix is one line: `AllocsPerRun(1, ...)` becomes `AllocsPerRun(100, ...)`. The function divides the total malloc delta by `runs` with integer division, so up to 99 stray allocations across the window read as 0, while a genuine allocation in the code under test occurs in every run and still reads as ≥ 1. The test body is otherwise unchanged.

Verified: 20 consecutive runs green plus 5 under `-race`; with a deliberate allocation injected into the closure, the test still fails every time.

The v3 line's copy of this test has the same `runs=1` pattern (with an easyjson-conditional expectation) and gets the same fix in #61.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Hardens** `TestReaderSkipValueAllocations` so flaky CI failures (e.g. Windows / Go 1.25 / `-race`) are less likely when unrelated process allocations bump `testing.AllocsPerRun` with a single run.
> 
> The measurement changes from **`AllocsPerRun(1, …)`** to **`AllocsPerRun(100, …)`**, with comments explaining that the counter is process-global and integer-averaging tolerates sporadic timer/finalizer noise while still reporting ≥1 when the closure allocates every iteration. The skip-value exercise and **0** expected allocation assertion are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fb41d95a01493077c401a78756be656fca9168c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->