### PR TITLE
chore: harden the skip-value allocation test against unrelated allocations

### DIFF
--- a/jreader/reader_test.go
+++ b/jreader/reader_test.go
@@ -424,7 +424,13 @@ func TestReaderSkipValueAllocations(t *testing.T) {
 
 	data := []byte(`{"a":1, "b":{"b1":"two", "b2":"three"}, "c":4}`)
 
-	allocs := testing.AllocsPerRun(1, func() {
+	// AllocsPerRun reads an allocation counter that applies to the whole process. An
+	// unrelated allocation on another goroutine, for example a timer or a finalizer, can
+	// increase the result of a single run. The average of 100 runs removes these errors,
+	// because AllocsPerRun divides the total allocation count by the run count and
+	// truncates the result. An allocation in the code under test occurs in each run, so
+	// the result stays 1 or more.
+	allocs := testing.AllocsPerRun(100, func() {
 		r := NewReader(data)
 		obj := r.Object()
 		require.NoError(t, r.Error())


### PR DESCRIPTION
v3 counterpart of #60 — the same one-line change: `AllocsPerRun(1, ...)` becomes `AllocsPerRun(100, ...)`, with the test body otherwise unchanged. The easyjson-conditional expectation is preserved: that build's exactly-4-allocations-per-parse count is deterministic and holds under the averaging (the integer division yields 400/100 = 4). Verified under both build tags, including `-race`.

See #60 for the analysis: `AllocsPerRun` samples the process-global malloc counter, so `runs=1` makes the assertion "nothing anywhere in the process allocates during the window" — one stray timer or finalizer allocation on a slow runner reads as a failure. Averaging over 100 runs absorbs strays through the integer division, while a genuine allocation in the code under test occurs in every run and still fails.

No interaction with the open backport PRs (#56/#57/#58) — none of them touch this file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Hardens `TestReaderSkipValueAllocations`** so flaky CI failures from unrelated process allocations are less likely.
> 
> The test still parses the same JSON and skips the nested `b` object while reading `a` and `c`, and still expects **0** allocs (or **4** under the easyjson build tag). The only behavioral change is **`testing.AllocsPerRun(1, …)` → `testing.AllocsPerRun(100, …)`**, with comments explaining that `AllocsPerRun` uses a process-wide counter, so a single run can fail if another goroutine allocates; averaging 100 runs smooths stray timer/finalizer noise while real per-run allocs in the code under test still fail the assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 121ae6ced22df92878eb587e09fb985e93c58bb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->