### PR TITLE
ci: use shared sdk-go-versions workflow

### DIFF
--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -8,14 +8,9 @@ permissions: {}
 
 jobs:
   check-go-versions:
-    # The called workflow narrows check-go-eol to `contents: read`; a reusable workflow
-    # cannot grant itself more than the caller does, which is why the write scopes are here.
     permissions:
       contents: write
       pull-requests: write
-    # Reusable workflows in gh-actions are consumed at @main; release-please does not version
-    # them (see launchdarkly/gh-actions#51). The composite action that workflow calls is
-    # pinned to an exact release tag on that side.
     uses: launchdarkly/gh-actions/.github/workflows/sdk-go-versions.yml@main
     with:
       branches: '["v3", "v4"]'

--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -4,15 +4,18 @@ on:
     - cron: "0 17 * * *"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   check-go-eol:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       latest: ${{ steps.parse.outputs.latest }}
       penultimate: ${{ steps.parse.outputs.penultimate }}
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v4
         # Perform a GET request to endoflife.date for the Go language. The response
         # contains all Go releases; we're interested in the 0'th and 1'th (latest and penultimate.)
       - name: Fetch officially supported Go versions
@@ -24,9 +27,20 @@ jobs:
         # Parse the response JSON and insert into environment variables for the next step.
       - name: Parse officially supported Go versions
         id: parse
+        env:
+          FETCH_API_DATA: ${{ env.fetch-api-data }}
         run: |
-          echo "latest=${{ fromJSON(env.fetch-api-data)[0].cycle }}" >> $GITHUB_OUTPUT
-          echo "penultimate=${{ fromJSON(env.fetch-api-data)[1].cycle }}" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          latest=$(jq -r '.[0].cycle' <<< "$FETCH_API_DATA")
+          penultimate=$(jq -r '.[1].cycle' <<< "$FETCH_API_DATA")
+          for version in "$latest" "$penultimate"; do
+            if [[ ! "$version" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+              echo "Unexpected Go version string from endoflife.date: $version" >&2
+              exit 1
+            fi
+          done
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+          echo "penultimate=$penultimate" >> "$GITHUB_OUTPUT"
 
 
   create-prs:
@@ -49,14 +63,15 @@ jobs:
 
       - name: Get current Go versions
         id: go-versions
-        run:  cat ./.github/variables/go-versions.env > $GITHUB_OUTPUT
+        run:  cat ./.github/variables/go-versions.env >> "$GITHUB_OUTPUT"
 
       - name: Update go-versions.env and README.md
         if: steps.go-versions.outputs.latest != env.officialLatestVersion
         id: update-go-versions
         run: |
-          sed -i -e "s#latest=[^ ]*#latest=${{ env.officialLatestVersion }}#g" \
-                 -e "s#penultimate=[^ ]*#penultimate=${{ env.officialPenultimateVersion }}#g" \
+          set -euo pipefail
+          sed -i -e "s#latest=[^ ]*#latest=$officialLatestVersion#g" \
+                 -e "s#penultimate=[^ ]*#penultimate=$officialPenultimateVersion#g" \
                   ./.github/variables/go-versions.env
 
       - name: Create pull request

--- a/.github/workflows/check-go-versions.yml
+++ b/.github/workflows/check-go-versions.yml
@@ -7,85 +7,15 @@ on:
 permissions: {}
 
 jobs:
-  check-go-eol:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      latest: ${{ steps.parse.outputs.latest }}
-      penultimate: ${{ steps.parse.outputs.penultimate }}
-    timeout-minutes: 2
-    steps:
-        # Perform a GET request to endoflife.date for the Go language. The response
-        # contains all Go releases; we're interested in the 0'th and 1'th (latest and penultimate.)
-      - name: Fetch officially supported Go versions
-        uses: JamesIves/fetch-api-data-action@396ebea7d13904824f85b892b1616985f847301c
-        with:
-          endpoint: https://endoflife.date/api/go.json
-          configuration: '{ "method": "GET" }'
-          debug: true
-        # Parse the response JSON and insert into environment variables for the next step.
-      - name: Parse officially supported Go versions
-        id: parse
-        env:
-          FETCH_API_DATA: ${{ env.fetch-api-data }}
-        run: |
-          set -euo pipefail
-          latest=$(jq -r '.[0].cycle' <<< "$FETCH_API_DATA")
-          penultimate=$(jq -r '.[1].cycle' <<< "$FETCH_API_DATA")
-          for version in "$latest" "$penultimate"; do
-            if [[ ! "$version" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-              echo "Unexpected Go version string from endoflife.date: $version" >&2
-              exit 1
-            fi
-          done
-          echo "latest=$latest" >> "$GITHUB_OUTPUT"
-          echo "penultimate=$penultimate" >> "$GITHUB_OUTPUT"
-
-
-  create-prs:
+  check-go-versions:
+    # The called workflow narrows check-go-eol to `contents: read`; a reusable workflow
+    # cannot grant itself more than the caller does, which is why the write scopes are here.
     permissions:
       contents: write
       pull-requests: write
-    needs: check-go-eol
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        branch: ["v3", "v4"]
-      fail-fast: false
-    env:
-      officialLatestVersion: ${{ needs.check-go-eol.outputs.latest }}
-      officialPenultimateVersion: ${{ needs.check-go-eol.outputs.penultimate }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ matrix.branch }}
-
-      - name: Get current Go versions
-        id: go-versions
-        run:  cat ./.github/variables/go-versions.env >> "$GITHUB_OUTPUT"
-
-      - name: Update go-versions.env and README.md
-        if: steps.go-versions.outputs.latest != env.officialLatestVersion
-        id: update-go-versions
-        run: |
-          set -euo pipefail
-          sed -i -e "s#latest=[^ ]*#latest=$officialLatestVersion#g" \
-                 -e "s#penultimate=[^ ]*#penultimate=$officialPenultimateVersion#g" \
-                  ./.github/variables/go-versions.env
-
-      - name: Create pull request
-        if: steps.update-go-versions.outcome == 'success'
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          add-paths: |
-            .github/variables/go-versions.env
-          branch: "launchdarklyreleasebot/update-to-go${{ env.officialLatestVersion }}-${{ matrix.branch }}"
-          author: "LaunchDarklyReleaseBot <LaunchDarklyReleaseBot@launchdarkly.com>"
-          committer: "LaunchDarklyReleaseBot <LaunchDarklyReleaseBot@launchdarkly.com>"
-          labels: ${{ matrix.branch }}
-          title: "ci: bump tested Go versions to ${{ env.officialLatestVersion }} and ${{ env.officialPenultimateVersion }}"
-          commit-message: "Bumps from Go ${{ steps.go-versions.outputs.latest }} -> ${{ env.officialLatestVersion }} and ${{ steps.go-versions.outputs.penultimate }} -> ${{ env.officialPenultimateVersion }}."
-          body: |
-            - [ ] I have triggered CI on this PR (either close & reopen this PR in Github UI, or `git commit -m "run ci" --allow-empty && git push`)
+    # Reusable workflows in gh-actions are consumed at @main; release-please does not version
+    # them (see launchdarkly/gh-actions#51). The composite action that workflow calls is
+    # pinned to an exact release tag on that side.
+    uses: launchdarkly/gh-actions/.github/workflows/sdk-go-versions.yml@main
+    with:
+      branches: '["v3", "v4"]'


### PR DESCRIPTION
Replaces this repo's copy of the Go version check with a call to the shared `sdk-go-versions` reusable workflow, deleting the inline shell entirely.

### Why this supersedes the previous approach

The earlier revision of this PR hardened the inline shell in place — the port of launchdarkly/ld-relay#841 (SEC-9481): untrusted endoflife.date data moved into quoted env vars, `jq` extraction, strict version validation. That fixed the specific injection, but the shell was still here to be fixed.

Calling the shared workflow removes the shell from this repo altogether, so the script-injection class is structurally unavailable here rather than merely fixed. 91 lines become 21.

The shared workflow pins the composite action to the released `go-eol-versions-v0.1.0`; consumers track the workflow itself at `@main`, matching how this org already consumes `sdk-stale` and `dependency-scan`. (Reusable workflows in gh-actions are not versioned by release-please — see launchdarkly/gh-actions#51 — so `@main` is the supported reference, and the pinning happens on the action inside.)

### Inputs

- `branches: '["v3", "v4"]'` — the two maintained major-version branches of this repo, matching the strategy matrix the inline workflow used.

Everything else is left at its default: `precision` (`cycle`), `versions_file` (`.github/variables/go-versions.env`), `add_paths`, `pr_title_prefix` and `runs_on` all default to what this repo needs.

### Behaviour

Intended to be unchanged: same schedule (`0 17 * * *`), same file updated, same shape of bump PR. Two fixes the shared version carries that the inline copy did not:

- A penultimate-only upstream release now opens a PR. The inline gate compared only `latest`, so a change confined to the penultimate cycle was silently dropped.
- The bot branch name includes both versions, so a later bump does not collide with an open branch from an earlier one.

### Verification

- YAML parses and the job graph is the single reusable-workflow call: `python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/check-go-versions.yml')); print(d['jobs'])"` → `{'check-go-versions': {'permissions': {...}, 'uses': 'launchdarkly/gh-actions/.github/workflows/sdk-go-versions.yml@main', 'with': {'branches': '["v3", "v4"]'}}}`.
- No `run:` steps remain — `grep -c 'run:'` is 0. That is the point of the change.
- `grep -c 'fromJSON\|JamesIves\|peter-evans\|sed -i'` is 0: no third-party fetch action, no `create-pull-request` invocation and no in-repo `sed` left in this file.
- `git diff --stat` against `v4` touches only `.github/workflows/check-go-versions.yml` (11 insertions, 66 deletions).

The workflow was not dispatched from here — it is verified end to end in launchdarkly/go-test-helpers#37 ([run 33534426032](https://github.com/launchdarkly/go-test-helpers/actions/runs/33534426032)), and a dispatch against this branch could open a real bump PR.

---

**Requirements**

- [x] I have added test coverage for new or changed functionality — n/a — workflow-only change
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Tracked by SDK-3023. Shared workflow: launchdarkly/gh-actions#113. Supersedes the in-place hardening of SEC-9481 / launchdarkly/ld-relay#841 for this repo.

**Describe the solution you've provided**

Delete the inline `check-go-eol` + `create-prs` jobs and call `launchdarkly/gh-actions/.github/workflows/sdk-go-versions.yml@main` with `branches: '["v3", "v4"]'`. The caller keeps `contents: write` + `pull-requests: write` on the job because a reusable workflow cannot grant itself more permission than its caller; the called workflow narrows its own EOL-lookup job back down to `contents: read`.

**Describe alternatives you've considered**

Keeping the hardened inline shell (the previous revision of this PR) works, but leaves every consuming repo with its own copy to keep hardened. Vendoring the composite action directly instead of the reusable workflow was also considered, but that would put the job wiring — permissions, matrix over branches, PR creation — back in each repo.

**Additional context**

The inline `check-go-eol` job fed a downstream job holding `contents: write` + `pull-requests: write`, which is what made the injection worth fixing rather than merely tidying. That downstream job now lives in gh-actions, reviewed once.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> **Replaces the local Go version bump automation** with a call to `launchdarkly/gh-actions/.github/workflows/sdk-go-versions.yml@main`, removing ~60 lines of inline jobs (`check-go-eol`, matrix `create-prs`, `fetch-api-data`, `sed`, and `create-pull-request`).
> 
> The scheduled and `workflow_dispatch` triggers are unchanged. The new job still targets branches **`v3`** and **`v4`** via `with.branches`, and keeps **`contents: write`** and **`pull-requests: write`** on the caller job so bump PRs can be opened. Top-level **`permissions: {}`** is added on the workflow.
> 
> Version lookup and PR creation now live in the shared workflow (pinned composite action there), which removes in-repo shell/script steps and centralizes fixes such as opening PRs when only the penultimate Go cycle changes and using branch names that include both versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09fbf73e46f04c9b8b5e1625dc07696a0e4ed033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->